### PR TITLE
[Feature/#138]마이페이지, 티켓조회 API 연결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "kr.object.ncloudstorage.com",
+        hostname: "movie-bookie-storage.kr.object.ncloudstorage.com",
       },
     ],
   },

--- a/src/app/(fullscreen)/event-completed/page.tsx
+++ b/src/app/(fullscreen)/event-completed/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { Button, FixedLayout } from "@/components";
+import { PATHS } from "@/constants";
+
+export default function EventCompletedPage() {
+  const router = useRouter();
+
+  const handleComplete = () => {
+    router.push(PATHS.FEEDBACK);
+  };
+
+  const handleCancel = () => {
+    router.push(PATHS.HOME);
+  };
+
+  return (
+    <>
+      <FixedLayout
+        title="이벤트 상영 완료"
+        showBackButton
+        isHeader
+        showBottomButton={false}
+        state="default"
+      >
+        <div className="mt-31 flex flex-col items-center justify-center text-center">
+          <div className="relative mb-6 aspect-square w-[200px]">
+            <Image
+              src="/images/image.png"
+              alt="이벤트 포스터"
+              fill
+              className="rounded-xl object-cover"
+            />
+          </div>
+          <div className="body-2-semibold text-white">
+            “더 폴: 오디언스와 환상의 문”
+          </div>
+          <div className="title-2-semibold mt-1 text-white">
+            이벤트 상영은 잘 완료되었나요?
+          </div>
+        </div>
+      </FixedLayout>
+
+      <div className="bg-gray-black fixed bottom-0 z-50 w-full max-w-125 px-5 pt-5 pb-12.5">
+        <div className="flex flex-col gap-3">
+          <Button className="bg-red-main text-white" onClick={handleComplete}>
+            네, 상영이 완료되었어요
+          </Button>
+          <Button className="bg-gray-800 text-white" onClick={handleCancel}>
+            아니요, 상영이 취소되었어요
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(fullscreen)/event/ticket/_components/card-back.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/card-back.tsx
@@ -21,24 +21,36 @@ export default function CardBack({ ticket }: { ticket: any }) {
       <div className="bg-gray-white mt-2.25 h-0.25 w-full opacity-14" />
 
       <div className="mt-5 grid grid-cols-[auto_1fr] gap-x-4.5 gap-y-2">
-        {cardInfo.map(({ label, value, isSectionStart }) => (
-          <Fragment key={label}>
-            <p
-              className={`caption-1-medium text-gray-200 ${
-                isSectionStart ? "mt-3" : ""
-              }`}
-            >
-              {label}
-            </p>
-            <p
-              className={`caption-1-regular text-gray-100 ${
-                isSectionStart ? "mt-3" : ""
-              }`}
-            >
-              {value}
-            </p>
-          </Fragment>
-        ))}
+        {cardInfo.map(({ label, value, isSectionStart }) => {
+          let displayValue = value;
+
+          if (label === "가격" && typeof value === "number") {
+            displayValue = `${value.toLocaleString()}원`;
+          }
+
+          if (label === "인원" && typeof value === "number") {
+            displayValue = `모집인원 ${value}명`;
+          }
+
+          return (
+            <Fragment key={label}>
+              <p
+                className={`caption-1-medium text-gray-200 ${
+                  isSectionStart ? "mt-3" : ""
+                }`}
+              >
+                {label}
+              </p>
+              <p
+                className={`caption-1-regular text-gray-100 ${
+                  isSectionStart ? "mt-3" : ""
+                }`}
+              >
+                {displayValue}
+              </p>
+            </Fragment>
+          );
+        })}
       </div>
 
       <LogoWhiteIcon

--- a/src/app/(fullscreen)/event/ticket/_components/card-back.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/card-back.tsx
@@ -1,21 +1,21 @@
 import { LogoWhiteIcon } from "@/icons/index";
 import { Fragment } from "react";
 
-const cardInfo = [
-  { label: "위치", value: "서울특별시 어쩌구 저쩌구 무슨로" },
-  { label: "일시", value: "2025. 05. 26 (일)" },
-  { label: "시간", value: "18:00~20:24" },
-  { label: "인원", value: "모집인원 24명", isSectionStart: true },
-  { label: "가격", value: "24,000원" },
-  { label: "주최", value: "김서현" },
-];
+export default function CardBack({ ticket }: { ticket: any }) {
+  const cardInfo = [
+    { label: "위치", value: ticket?.address },
+    { label: "일시", value: ticket?.scheduledAt },
+    { label: "시간", value: ticket?.time },
+    { label: "인원", value: ticket?.participants, isSectionStart: true },
+    { label: "가격", value: ticket?.price },
+    { label: "주최", value: ticket?.hostName },
+  ];
 
-export default function CardBack() {
   return (
     <div className="card-shadow-blur absolute h-full w-full rotate-y-180 overflow-hidden rounded-[20px] bg-white/30 px-3.5 pb-4 backface-hidden">
-      <h2 className="title-3-bold mt-17.25">빌리 엘리어트</h2>
+      <h2 className="title-3-bold mt-17.25">{ticket?.title}</h2>
       <h3 className="caption-1-medium mt-0.5 text-gray-200">
-        (영화) 신촌 아트레온
+        ({ticket?.type}) {ticket?.location}
       </h3>
 
       <div className="bg-gray-white mt-2.25 h-0.25 w-full opacity-14" />

--- a/src/app/(fullscreen)/event/ticket/_components/card-front.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/card-front.tsx
@@ -7,6 +7,7 @@ export default function CardFront({ ticket }: { ticket: any }) {
     { label: "장소", value: ticket?.location },
     { label: "예상 금액", value: ticket?.price },
   ];
+
   return (
     <div className="card-shadow-blur absolute h-full w-full overflow-hidden rounded-[20px] bg-white/30 p-3 backface-hidden">
       <div className="relative h-66.25 w-66.25 overflow-hidden">
@@ -19,12 +20,19 @@ export default function CardFront({ ticket }: { ticket: any }) {
       </div>
       <p className="title-3-bold mt-5 pl-0.5">{ticket?.title}</p>
       <div className="mt-2.5 grid grid-cols-3 gap-x-6 gap-y-1.5 pl-0.5">
-        {infoData.map(({ label, value }) => (
-          <div key={label} className="flex flex-col items-start">
-            <h2 className="caption-3-medium opacity-48">{label}</h2>
-            <p className="caption-1-medium opacity-48">{value}</p>
-          </div>
-        ))}
+        {infoData.map(({ label, value }) => {
+          const displayValue =
+            label === "예상 금액" && typeof value === "number"
+              ? `${value.toLocaleString()}원`
+              : value;
+
+          return (
+            <div key={label} className="flex flex-col items-start">
+              <h2 className="caption-3-medium opacity-48">{label}</h2>
+              <p className="caption-1-medium opacity-48">{displayValue}</p>
+            </div>
+          );
+        })}
       </div>
 
       <LogoWhiteIcon

--- a/src/app/(fullscreen)/event/ticket/_components/card-front.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/card-front.tsx
@@ -1,26 +1,23 @@
-import { MOCK_IMAGES } from "@/constants/path-images";
 import { LogoWhiteIcon } from "@/icons/index";
 import Image from "next/image";
-import { Fragment } from "react";
 
-const infoData = [
-  { label: "일시", value: "2025. 05. 26" },
-  { label: "장소", value: "신촌 아트레온" },
-  { label: "예상 금액", value: "24,000원" },
-];
-
-export default function CardFront() {
+export default function CardFront({ ticket }: { ticket: any }) {
+  const infoData = [
+    { label: "일시", value: ticket?.scheduledAt },
+    { label: "장소", value: ticket?.location },
+    { label: "예상 금액", value: ticket?.price },
+  ];
   return (
     <div className="card-shadow-blur absolute h-full w-full overflow-hidden rounded-[20px] bg-white/30 p-3 backface-hidden">
       <div className="relative h-66.25 w-66.25 overflow-hidden">
         <Image
-          src={MOCK_IMAGES.IMAGE_1}
+          src={ticket?.eventImageUrl}
           fill
           alt="ticket-image"
           className="rounded-lg object-cover"
         />
       </div>
-      <p className="title-3-bold mt-5 pl-0.5">빌리 엘리어트</p>
+      <p className="title-3-bold mt-5 pl-0.5">{ticket?.title}</p>
       <div className="mt-2.5 grid grid-cols-3 gap-x-6 gap-y-1.5 pl-0.5">
         {infoData.map(({ label, value }) => (
           <div key={label} className="flex flex-col items-start">

--- a/src/app/(fullscreen)/event/ticket/_components/client.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/client.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useState } from "react";
-import CardBack from "./card-back";
+import { useSearchParams } from "next/navigation";
 import CardFront from "./card-front";
+import CardBack from "./card-back";
 import { RotateIcon } from "@/icons/index";
+import { useState } from "react";
+import { useTicketDetail } from "app/_hooks/events/use-ticket-detail";
+import Loading from "app/loading";
 
-export default function Client() {
+export default function TicketPage() {
+  const searchParams = useSearchParams();
+  const ticketId = searchParams.get("id");
+  const { data: ticket, isLoading } = useTicketDetail(ticketId);
   const [flipped, setFlipped] = useState(false);
+
+  if (isLoading) return <Loading />;
+  if (!ticket)
+    return <p className="text-center text-white">티켓이 없습니다.</p>;
 
   return (
     <div className="flex h-full flex-col items-center justify-center gap-8.5">
@@ -16,8 +26,8 @@ export default function Client() {
           flipped ? "rotate-y-180" : ""
         }`}
       >
-        <CardFront />
-        <CardBack />
+        <CardFront ticket={ticket} />
+        <CardBack ticket={ticket} />
       </div>
       <button
         type="button"

--- a/src/app/(fullscreen)/feedback/page.tsx
+++ b/src/app/(fullscreen)/feedback/page.tsx
@@ -1,100 +1,55 @@
 "use client";
 
-import Image from "next/image";
-import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button, FixedLayout } from "@/components";
-import { PATHS } from "@/constants";
+import { FixedLayout } from "@/components";
 import { KissingFaceIcon, ThinkingFaceIcon } from "@/icons/index";
+import { PATHS } from "@/constants";
 
-export default function EventCompletePage() {
+export default function FeedbackStartPage() {
   const router = useRouter();
-  const [isFeedbackMode, setIsFeedbackMode] = useState(false);
-
-  const handleComplete = () => {
-    setIsFeedbackMode(true);
-  };
-
-  const handleCancel = () => {
-    router.push(PATHS.HOME);
-  };
 
   const handleFeedback = (type: "bad" | "good") => {
     router.push(PATHS.FEEDBACK_RESULT_WITH_TYPE(type));
   };
 
   return (
-    <>
-      <FixedLayout
-        title={isFeedbackMode ? "평가 및 피드백" : "이벤트 상영 완료"}
-        showBackButton
-        isHeader
-        showBottomButton={false}
-        state="default"
-      >
-        {!isFeedbackMode ? (
-          <div className="mt-31 flex flex-col items-center justify-center text-center">
-            <div className="relative mb-6 aspect-square w-[200px]">
-              <Image
-                src="/images/image.png"
-                alt="이벤트 포스터"
-                fill
-                className="rounded-xl object-cover"
-              />
-            </div>
-            <div className="body-2-semibold text-white">
-              “더 폴: 오디언스와 환상의 문”
-            </div>
-            <div className="title-2-semibold mt-1 text-white">
-              이벤트 상영은 잘 완료되었나요?
-            </div>
+    <FixedLayout
+      title="평가 및 피드백"
+      showBackButton
+      isHeader
+      showBottomButton={false}
+      state="default"
+    >
+      <div className="mt-33.5 flex flex-col items-center justify-start gap-13 text-center">
+        <div>
+          <div className="title-1-semibold mb-2 text-white">
+            무비부키와 함께한 시간, <br /> 만족스러우셨나요?
           </div>
-        ) : (
-          <div className="mt-33.5 flex flex-col items-center justify-start gap-13 text-center">
-            <div>
-              <div className="title-1-semibold mb-2 text-white">
-                무비부키와 함께한 시간, <br /> 만족스러우셨나요?
-              </div>
-              <div className="caption-1-medium text-gray-500">
-                작은 의견도 저희에겐 큰 도움이 돼요
-              </div>
-            </div>
-            <div className="flex gap-5">
-              <button
-                onClick={() => handleFeedback("bad")}
-                className="flex flex-col items-center justify-center rounded-xl border border-gray-900 bg-transparent px-14 py-8 text-gray-100"
-              >
-                <div className="mb-2 text-3xl">
-                  <ThinkingFaceIcon />
-                </div>
-                <div className="body-3-regular">아쉬워요</div>
-              </button>
-              <button
-                onClick={() => handleFeedback("good")}
-                className="flex flex-col items-center justify-center rounded-xl border border-gray-900 bg-transparent px-14 py-8 text-gray-100"
-              >
-                <div className="mb-2 text-3xl">
-                  <KissingFaceIcon />
-                </div>
-                <div className="body-3-regular">만족해요</div>
-              </button>
-            </div>
-          </div>
-        )}
-      </FixedLayout>
-
-      {!isFeedbackMode && (
-        <div className="bg-gray-black fixed bottom-0 z-50 w-full max-w-125 px-5 pt-5 pb-12.5">
-          <div className="flex flex-col gap-3">
-            <Button className="bg-red-main text-white" onClick={handleComplete}>
-              네, 상영이 완료되었어요
-            </Button>
-            <Button className="bg-gray-800 text-white" onClick={handleCancel}>
-              아니요, 상영이 취소되었어요
-            </Button>
+          <div className="caption-1-medium text-gray-500">
+            작은 의견도 저희에겐 큰 도움이 돼요
           </div>
         </div>
-      )}
-    </>
+        <div className="flex gap-5">
+          <button
+            onClick={() => handleFeedback("bad")}
+            className="flex flex-col items-center justify-center rounded-xl border border-gray-900 bg-transparent px-14 py-8 text-gray-100"
+          >
+            <div className="mb-2 text-3xl">
+              <ThinkingFaceIcon />
+            </div>
+            <div className="body-3-regular">아쉬워요</div>
+          </button>
+          <button
+            onClick={() => handleFeedback("good")}
+            className="flex flex-col items-center justify-center rounded-xl border border-gray-900 bg-transparent px-14 py-8 text-gray-100"
+          >
+            <div className="mb-2 text-3xl">
+              <KissingFaceIcon />
+            </div>
+            <div className="body-3-regular">만족해요</div>
+          </button>
+        </div>
+      </div>
+    </FixedLayout>
   );
 }

--- a/src/app/(fullscreen)/feedback/result/page.tsx
+++ b/src/app/(fullscreen)/feedback/result/page.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from "react";
 import FeedbackPage from "./components/feedbackpage";
+import Loading from "app/loading";
 
 export default function FeedbackResultPage() {
   return (
-    <Suspense fallback={<div>로딩 중...</div>}>
+    <Suspense fallback={<Loading />}>
       <FeedbackPage />
     </Suspense>
   );

--- a/src/app/(fullscreen)/login/kakao/page.tsx
+++ b/src/app/(fullscreen)/login/kakao/page.tsx
@@ -52,8 +52,8 @@ function KakaoLogin() {
         const { success, data, message } = response;
 
         if (success) {
-          localStorage.setItem("userProfile", JSON.stringify(data));
           router.push(PATHS.AGREEMENT);
+          localStorage.setItem("userProfile", JSON.stringify(data));
         } else {
           router.push(`/login?error=${encodeURIComponent(message)}`);
         }

--- a/src/app/(tabs)/event/_components/event-tabs.tsx
+++ b/src/app/(tabs)/event/_components/event-tabs.tsx
@@ -2,7 +2,6 @@
 
 import { ToggleTab, Card } from "@/components";
 import { EmptyIcon } from "@/icons/index";
-import { mapEventCardToCardProps } from "@/utils/map-to-eventcard";
 import { useEventTabQuery } from "app/_hooks/events/use-event-tab-query";
 
 interface EventTabProps {
@@ -20,10 +19,7 @@ export default function EventTab({ type }: EventTabProps) {
   } = useEventTabQuery(type);
 
   if (isError) {
-    return (
-      <p className="text-center">이벤트를 불러오지 못했습니다.</p>
-      //TODO: 에러 처리
-    );
+    return <p className="text-center">이벤트를 불러오지 못했습니다.</p>;
   }
 
   return (
@@ -40,7 +36,21 @@ export default function EventTab({ type }: EventTabProps) {
         {events.length > 0 ? (
           events.map((event, index) => (
             <div key={event.eventId}>
-              <Card {...mapEventCardToCardProps(event)} />
+              <Card
+                imageUrl={event.posterImageUrl}
+                category={event.mediaType}
+                title={event.mediaTitle}
+                placeAndDate={`${event.locationName} · ${event.eventDate}`}
+                description={event.description}
+                ddayBadge={
+                  event.d_day !== null ? `D-${event.d_day}` : undefined
+                }
+                statusBadge={event.eventStatus}
+                progressRate={
+                  event.rate !== undefined ? `${event.rate}%` : undefined
+                }
+                estimatedPrice={event.estimatedPrice}
+              />
               {index < events.length - 1 && (
                 <div className="my-4 h-px w-full bg-gray-950" />
               )}

--- a/src/app/(tabs)/event/_components/ticket-card.tsx
+++ b/src/app/(tabs)/event/_components/ticket-card.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 export function Card({
+  id,
   imageUrl,
   title,
   placeAndDate,
@@ -17,9 +18,8 @@ export function Card({
   const router = useRouter();
 
   const handleClick = () => {
-    router.push("/event/ticket");
+    router.push(`/event/ticket?id=${id}`);
   };
-
   return (
     <div
       onClick={handleClick}

--- a/src/app/(tabs)/event/_components/ticket-card.tsx
+++ b/src/app/(tabs)/event/_components/ticket-card.tsx
@@ -2,6 +2,7 @@
 
 import { CardProps } from "app/_types/card";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 export function Card({
   imageUrl,
@@ -13,8 +14,17 @@ export function Card({
   progressRate,
   estimatedPrice,
 }: CardProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/event/ticket");
+  };
+
   return (
-    <div className="relative flex flex-col overflow-hidden rounded-xl bg-gray-950">
+    <div
+      onClick={handleClick}
+      className="relative flex flex-col overflow-hidden rounded-xl bg-gray-950"
+    >
       <div className="relative h-41.75 w-full overflow-hidden">
         <Image src={imageUrl} alt={title} fill className="object-cover" />
         {(ddayBadge || statusBadge) && (

--- a/src/app/(tabs)/event/_components/ticket-tab.tsx
+++ b/src/app/(tabs)/event/_components/ticket-tab.tsx
@@ -2,21 +2,32 @@
 
 import { Card } from "./ticket-card";
 import { EmptyTicketIcon } from "@/icons/index";
-import { MOCK_DATA } from "@/mocks/mock-data";
-import { mapEventCardToCardProps } from "@/utils/map-to-eventcard";
+import { useTickets } from "app/_hooks/events/use-ticket";
+import Loading from "app/loading";
 
 export default function TicketTab() {
-  const filteredEvents = MOCK_DATA.filter((event) =>
-    ["대관확정", "상영완료"].includes(event.statusBadge),
-  );
+  const { data: tickets = [], isLoading } = useTickets();
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <div className="pb-24">
       <div className="mt-6 flex flex-col gap-5">
-        {filteredEvents.length > 0 ? (
-          filteredEvents.map((event, index) => (
-            <div key={index}>
-              <Card {...mapEventCardToCardProps(event)} />
+        {tickets.length > 0 ? (
+          tickets.map((ticket) => (
+            <div key={ticket.ticketId}>
+              <Card
+                id={ticket.ticketId}
+                imageUrl={ticket.eventImageUrl}
+                title={ticket.title}
+                placeAndDate={`${ticket.location} · ${ticket.scheduledAt}`}
+                description={ticket.description}
+                ddayBadge={null}
+                progressRate={undefined}
+                estimatedPrice={undefined}
+              />
             </div>
           ))
         ) : (

--- a/src/app/(tabs)/my-page/page.tsx
+++ b/src/app/(tabs)/my-page/page.tsx
@@ -3,14 +3,15 @@
 import Modal from "@/components/modal";
 import { PATHS } from "@/constants";
 import { ArrowRightIcon, DefaultProfileIcon, MyKakaoIcon } from "@/icons/index";
+import { useMyPage } from "app/_hooks/auth/use-mypage";
 import { useUserStore } from "app/_stores/useUserStore";
+import Loading from "app/loading";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 interface MyPageStatProps {
   label: string;
-  value: number | string;
+  value?: number | string;
 }
-
 function MyPageStat({ label, value }: MyPageStatProps) {
   return (
     <div className="py-5">
@@ -20,18 +21,29 @@ function MyPageStat({ label, value }: MyPageStatProps) {
   );
 }
 export default function MyPage() {
-  const user = useUserStore((state) => state.user);
-
+  const { data, isLoading, isError } = useMyPage();
   const router = useRouter();
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+  if (isError) {
+    return (
+      <div className="flex h-screen items-center justify-center text-red-500">
+        데이터를 불러오지 못했습니다. 다시 시도해주세요.
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen px-5 text-white">
       <h1 className="title-1-semibold pt-6 pb-7.5">마이페이지</h1>
       <div className="mb-5 flex items-center gap-4">
         <div className="border-red-main flex h-20 w-20 items-center justify-center rounded-full border-2">
-          {user && user.profileImage ? (
+          {data?.profileImage ? (
             <img
-              src={user.profileImage}
+              src={data.profileImage}
               alt="프로필"
               className="h-18 w-18 rounded-full"
             />
@@ -40,18 +52,22 @@ export default function MyPage() {
           )}
         </div>
         <div>
-          <p className="text-lg font-semibold">서현</p>
-          <p className="body-3-medium text-gray-500">
-            디테일 수집형 영화 덕후러
+          <p className="text-lg font-semibold">{data?.username}</p>
+          {/* <p className="body-3-medium text-gray-500">{data?.userType}</p> */}
+          <p className="body-3-medium text-gray-500">유저타입</p>
+          <p className="caption-1-medium text-gray-500">
+            {data?.certificationEmail}
           </p>
-          <p className="caption-1-medium text-gray-500">aoeidenkim@gmail.com</p>
         </div>
       </div>
       <div className="flex justify-center">
         <div className="mb-3 flex h-21.75 w-84 justify-around rounded-xl bg-gray-950 text-center">
-          <MyPageStat label="모집경험" value={0} />
-          <MyPageStat label="참여경험" value={8} />
-          <MyPageStat label="티켓" value={4} />
+          <MyPageStat label="모집경험" value={data?.hostExperienceCount} />
+          <MyPageStat
+            label="참여경험"
+            value={data?.participationExperienceCount}
+          />
+          <MyPageStat label="티켓" value={0} />
         </div>
       </div>
       <ul className="body-3-medium pl-2 text-gray-100">

--- a/src/app/_apis/auth/mypage.ts
+++ b/src/app/_apis/auth/mypage.ts
@@ -1,0 +1,14 @@
+import { apiGet } from "../methods";
+
+export interface MyPageResponse {
+  profileImage: string;
+  username: string;
+  userType: string;
+  certificationEmail: string;
+  hostExperienceCount: number;
+  participationExperienceCount: number;
+}
+
+export const getMyPageInfo = () => {
+  return apiGet<MyPageResponse>("/mypage");
+};

--- a/src/app/_apis/events/detail-ticket.ts
+++ b/src/app/_apis/events/detail-ticket.ts
@@ -1,0 +1,5 @@
+import { apiGet } from "../methods";
+
+export const fetchTickets = (page = 0, size = 10) => {
+  return apiGet<any[]>("/tickets", { page, size });
+};

--- a/src/app/_apis/methods.ts
+++ b/src/app/_apis/methods.ts
@@ -6,7 +6,7 @@ export const apiGet = async <T, P = Record<string, any>>(
   params?: P,
 ): Promise<T> => {
   const response = await axiosInstance.get<ApiResponse<T>>(url, { params });
-  return response.data.data;
+  return response.data.result;
 };
 
 export const apiPost = async <T, B = Record<string, any>>(
@@ -14,7 +14,7 @@ export const apiPost = async <T, B = Record<string, any>>(
   body?: B,
 ): Promise<T> => {
   const response = await axiosInstance.post<ApiResponse<T>>(url, body);
-  return response.data.data;
+  return response.data.result;
 };
 
 export const apiPatch = async <T, B = Record<string, any>>(
@@ -22,7 +22,7 @@ export const apiPatch = async <T, B = Record<string, any>>(
   body?: B,
 ): Promise<T> => {
   const response = await axiosInstance.patch<ApiResponse<T>>(url, body);
-  return response.data.data;
+  return response.data.result;
 };
 
 export const apiPut = async <T, B = Record<string, any>>(
@@ -30,7 +30,7 @@ export const apiPut = async <T, B = Record<string, any>>(
   body?: B,
 ): Promise<T> => {
   const response = await axiosInstance.put<ApiResponse<T>>(url, body);
-  return response.data.data;
+  return response.data.result;
 };
 
 export const apiDelete = async <T, P = Record<string, any>>(
@@ -38,5 +38,5 @@ export const apiDelete = async <T, P = Record<string, any>>(
   params?: P,
 ): Promise<T> => {
   const response = await axiosInstance.delete<ApiResponse<T>>(url, { params });
-  return response.data.data;
+  return response.data.result;
 };

--- a/src/app/_apis/type.ts
+++ b/src/app/_apis/type.ts
@@ -2,5 +2,5 @@ export interface ApiResponse<T> {
   httpStatus: string;
   code: string;
   message: string;
-  data: T;
+  result: T;
 }

--- a/src/app/_components/main-card.tsx
+++ b/src/app/_components/main-card.tsx
@@ -14,7 +14,7 @@ interface CardProps {
   ddayBadge?: string | null;
   statusBadge?: string;
   progressRate?: string;
-  estimatedPrice?: string;
+  estimatedPrice?: string | number;
 }
 
 export default function Card({
@@ -37,8 +37,8 @@ export default function Card({
     >
       <div className="relative h-30 w-30 overflow-hidden rounded-md">
         <Image
-          src={imageUrl}
-          alt="포스터 이미지"
+          src={imageUrl || "/images/default-image.png"}
+          alt={title}
           fill
           className="object-cover"
         />

--- a/src/app/_hooks/auth/use-mypage.tsx
+++ b/src/app/_hooks/auth/use-mypage.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyPageInfo } from "app/_apis/auth/mypage";
+
+export const useMyPage = () => {
+  return useQuery({
+    queryKey: ["my-page"],
+    queryFn: getMyPageInfo,
+  });
+};

--- a/src/app/_hooks/events/use-ticket-detail.ts
+++ b/src/app/_hooks/events/use-ticket-detail.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "app/_apis/methods";
+
+export const useTicketDetail = (ticketId: string | null) => {
+  return useQuery({
+    queryKey: ["ticket", ticketId],
+    queryFn: () => apiGet(`/tickets/${ticketId}`),
+    enabled: !!ticketId,
+  });
+};

--- a/src/app/_hooks/events/use-ticket.ts
+++ b/src/app/_hooks/events/use-ticket.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchTickets } from "app/_apis/events/detail-ticket";
+
+export const useTickets = (page = 0, size = 10) => {
+  return useQuery({
+    queryKey: ["tickets", page, size],
+    queryFn: () => fetchTickets(page, size),
+  });
+};

--- a/src/app/_types/card.ts
+++ b/src/app/_types/card.ts
@@ -12,7 +12,7 @@ export interface EventCard {
   posterImageUrl: string;
 }
 export interface CardProps {
-  id?: string;
+  id?: string | number;
   imageUrl: string;
   category?: string;
   title: string;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #138 


## ✅ PR 요약

<!-- 이번 PR에서 변경된 핵심 내용을 간결하게 설명해주세요. -->
- 마이페이지
- 티켓 관련 API 

---
## 📋 작업 상세 내용
- 마이페이지 정보 get API 연결 완료
- 이벤트탭에 티켓목록 API 연결완료
-  티켓 클릭시 티켓 상세 조회 API 연결
-  피드백 페이지 분리( 피그마 피드백쪽에 있는 상영완료 페이지는 알림 클릭했을떄만 이동하는 페이지라 분리했습니다)

---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->


https://github.com/user-attachments/assets/f40f4087-7d4b-424d-84e2-8d508e8eaf07


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
