### PR TITLE
[Feature/#180]이벤트 최신순 정렬, 배포주소에서 알림 안뜨는 이슈

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -34,6 +34,11 @@ messaging.onBackgroundMessage(function (payload) {
 });
 
 self.addEventListener("notificationclick", function (event) {
+  const eventId = event.notification.data?.eventId;
+  const urlToOpen = eventId
+    ? `/notifications?eventId=${eventId}`
+    : "/notifications";
+
   event.notification.close();
 
   event.waitUntil(
@@ -41,14 +46,9 @@ self.addEventListener("notificationclick", function (event) {
       .matchAll({ type: "window", includeUncontrolled: true })
       .then((clientList) => {
         for (const client of clientList) {
-          if (client.url.includes(targetUrl) && "focus" in client) {
-            return client.focus();
-          }
+          if ("focus" in client) return client.focus();
         }
-
-        if (clients.openWindow) {
-          return clients.openWindow(targetUrl);
-        }
+        if (clients.openWindow) return clients.openWindow(urlToOpen);
       }),
   );
 });

--- a/src/app/(tabs)/event/_components/event-tabs.tsx
+++ b/src/app/(tabs)/event/_components/event-tabs.tsx
@@ -38,29 +38,35 @@ export default function EventTab({ type }: EventTabProps) {
 
       <div className="mt-6 flex flex-col">
         {events.length > 0 ? (
-          events.map((event, index) => (
-            <div key={event.eventId}>
-              <Card
-                id={event.eventId}
-                imageUrl={event.posterImageUrl}
-                category={event.mediaType}
-                title={event.mediaTitle}
-                placeAndDate={`${event.locationName} · ${event.eventDate}`}
-                description={event.description}
-                ddayBadge={
-                  event.d_day !== null ? `D-${event.d_day}` : undefined
-                }
-                statusBadge={event.eventStatus}
-                progressRate={
-                  event.rate !== undefined ? `${event.rate}%` : undefined
-                }
-                estimatedPrice={event.estimatedPrice}
-              />
-              {index < events.length - 1 && (
-                <div className="my-4 h-px w-full bg-gray-950" />
-              )}
-            </div>
-          ))
+          [...events]
+            .sort(
+              (a, b) =>
+                new Date(b.eventDate).getTime() -
+                new Date(a.eventDate).getTime(),
+            ) // 최신순 정렬
+            .map((event, index) => (
+              <div key={event.eventId}>
+                <Card
+                  id={event.eventId}
+                  imageUrl={event.posterImageUrl}
+                  category={event.mediaType}
+                  title={event.mediaTitle}
+                  placeAndDate={`${event.locationName} · ${event.eventDate}`}
+                  description={event.description}
+                  ddayBadge={
+                    event.d_day !== null ? `D-${event.d_day}` : undefined
+                  }
+                  statusBadge={event.eventStatus}
+                  progressRate={
+                    event.rate !== undefined ? `${event.rate}%` : undefined
+                  }
+                  estimatedPrice={event.estimatedPrice}
+                />
+                {index < events.length - 1 && (
+                  <div className="my-4 h-px w-full bg-gray-950" />
+                )}
+              </div>
+            ))
         ) : (
           <div className="flex flex-col items-center justify-center pt-11 text-center text-gray-500">
             <EmptyIcon />

--- a/src/app/(tabs)/notifications/page.tsx
+++ b/src/app/(tabs)/notifications/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 import { useNotificationStore } from "app/_stores/use-noti";
 import { NotificationItem } from "./components/item";
+import { useEffect } from "react";
 
 export default function NotificationPage() {
   const { list, markAsRead } = useNotificationStore();
+
+  useEffect(() => {
+    console.log("🔔 알림 목록 (zustand):", list);
+  }, [list]);
 
   return (
     <div className="min-h-screen text-white">

--- a/src/app/_stores/use-noti.ts
+++ b/src/app/_stores/use-noti.ts
@@ -6,7 +6,7 @@ export type NotificationStatus = "confirm" | "cancel" | "check";
 
 interface NotificationState {
   list: NotificationItem[];
-  addNotification: (noti: NotificationItem) => void;
+  addNotification: (n: NotificationItem) => void;
   markAsRead: (index: number) => void;
   clearNotifications: () => void;
 }
@@ -16,15 +16,20 @@ export const useNotificationStore = create<NotificationState>()(
     (set) => ({
       list: [],
       addNotification: (noti) =>
-        set((state) => ({ list: [noti, ...state.list] })),
+        set((state) => {
+          const newList = [noti, ...state.list].slice(0, 50);
+          return { list: newList };
+        }),
       markAsRead: (index) =>
         set((state) => {
           const updated = [...state.list];
-          updated[index] = { ...updated[index], isRead: true };
+          if (updated[index]) updated[index].isRead = true;
           return { list: updated };
         }),
       clearNotifications: () => set({ list: [] }),
     }),
-    { name: "notification-store" },
+    {
+      name: "notifications-store",
+    },
   ),
 );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #180 

---
## 📋 작업 상세 내용
- 로컬에서는 알림 잘오는데 배포주소에서는 알림탭에 데이터들이 안보여서 수정했습니다. 
- 이벤트탭 최신이 위로오게끔 수정했습니다 .

---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notifications now open a relevant page based on event details when clicked, enhancing navigation from notification alerts.

- **Improvements**
  - Event lists are now sorted by date, displaying the newest events first for easier browsing.
  - The notifications list automatically limits to the 50 most recent items, improving performance and usability.

- **Bug Fixes**
  - Improved reliability when marking notifications as read.

- **Chores**
  - Internal logging added for notification lists to support debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->