### PR TITLE
[Feature/#184] store 값으로 유저조회, 소셜계정 페이지 UI

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,3 +1,4 @@
+importScripts("../src/scripts/generate-firebase-config");
 self.FIREBASE_CONFIG = {
   apiKey: "__API_KEY__",
   authDomain: "__AUTH_DOMAIN__",

--- a/src/app/(fullscreen)/(my-page)/accounts/page.tsx
+++ b/src/app/(fullscreen)/(my-page)/accounts/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { FixedLayout } from "@/components";
+import { MyKakaoIcon } from "@/icons/index";
+import { useUserStore } from "app/_stores/useUserStore";
+
 export default function PrivacyPolicy() {
+  const user = useUserStore((state) => state.user);
+
   return (
     <FixedLayout
       title="연결된 소셜 계정"
@@ -11,7 +16,17 @@ export default function PrivacyPolicy() {
       showBottomButton={false}
       state="default"
     >
-      <div className="text-gray-200">//TODO: 연결된 소셜 계정 추가</div>
+      <div>
+        <div className="flex items-center gap-2 rounded-xl bg-gray-900 px-5 py-4">
+          <div className="flex h-6 w-6 items-center justify-center pb-5">
+            <MyKakaoIcon />
+          </div>
+          <div className="flex flex-col">
+            <p className="caption-1-medium mb-0.5 text-gray-500">카카오 계정</p>
+            <p className="body-3-regular text-gray-200">{user?.email}</p>
+          </div>
+        </div>
+      </div>
     </FixedLayout>
   );
 }

--- a/src/app/(fullscreen)/login/kakao/page.tsx
+++ b/src/app/(fullscreen)/login/kakao/page.tsx
@@ -49,10 +49,9 @@ function KakaoLogin() {
           isLocal,
         });
 
-        const { success, data, message } = response;
+        const { success, message } = response;
 
         if (success) {
-          localStorage.setItem("userProfile", JSON.stringify(data));
           router.push(PATHS.AGREEMENT);
         } else {
           router.push(`/login?error=${encodeURIComponent(message)}`);

--- a/src/app/(fullscreen)/set-profile/page.tsx
+++ b/src/app/(fullscreen)/set-profile/page.tsx
@@ -5,12 +5,11 @@ import { DefaultProfileIcon } from "@/icons/index";
 import { useRouter } from "next/navigation";
 import Loading from "app/loading";
 import { formatPhoneNumberToBasic } from "@/utils/format-phone";
-import { useUserInfo } from "app/_hooks/use-user-info";
+import { useMyPage } from "app/_hooks/auth/use-mypage";
 
 export default function VerifyFlow() {
   const router = useRouter();
-
-  const { data: userInfo, isLoading, isError } = useUserInfo();
+  const { data: userInfo, isLoading, isError } = useMyPage();
   if (isLoading) {
     return <Loading />;
   }
@@ -64,10 +63,10 @@ export default function VerifyFlow() {
               {userInfo.username}
             </div>
             <div className="caption-1-medium mt-1 text-gray-500">
-              {userInfo.email}
+              {userInfo.certificationEmail}
             </div>
             <div className="caption-1-medium mt-1 text-gray-500">
-              {formatPhoneNumberToBasic(userInfo.phoneNumber)}
+              {/* {formatPhoneNumberToBasic(userInfo.phoneNumber)} */}
             </div>
           </div>
         )}

--- a/src/app/(fullscreen)/set-profile/page.tsx
+++ b/src/app/(fullscreen)/set-profile/page.tsx
@@ -66,7 +66,7 @@ export default function VerifyFlow() {
               {userInfo.certificationEmail}
             </div>
             <div className="caption-1-medium mt-1 text-gray-500">
-              {/* {formatPhoneNumberToBasic(userInfo.phoneNumber)} */}
+              {formatPhoneNumberToBasic(userInfo.phoneNumber)}
             </div>
           </div>
         )}

--- a/src/app/(fullscreen)/trait-result/page.tsx
+++ b/src/app/(fullscreen)/trait-result/page.tsx
@@ -8,15 +8,26 @@ import { useGetUserTypeResult } from "app/_hooks/use-user-type";
 import { useUserStore } from "app/_stores/useUserStore";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function TraitResult() {
   const router = useRouter();
+
   const handleClick = () => {
     router.push(PATHS.HOME);
   };
-  //TODO: 렌더링 문제 해결(유저 네임 깜빡임 문제)
 
   const { data } = useGetUserTypeResult();
+  const setUser = useUserStore((state) => state.setUser);
+  const user = useUserStore((state) => state.user);
+
+  useEffect(() => {
+    if (!user || !data?.title) return;
+    if (user.userTypeTitle === data.title) return;
+
+    const cleanedTitle = data.title.replace(/\n/g, " ");
+    setUser({ ...user, userTypeTitle: cleanedTitle });
+  }, [data?.title, user?.userTypeTitle, setUser]);
 
   const imageSrc =
     data?.userTypeCode &&

--- a/src/app/(fullscreen)/trait/page.tsx
+++ b/src/app/(fullscreen)/trait/page.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import { FixedLayout } from "@/components";
 import { usePostUserType } from "app/_hooks/use-user-type";
 import { useUserStore } from "app/_stores/useUserStore";
+import { useMyPage } from "app/_hooks/auth/use-mypage";
 
 export default function Trait() {
   const router = useRouter();
@@ -17,9 +18,9 @@ export default function Trait() {
   const methods = useForm({
     defaultValues: { mood: "", criterion: "", content: "" },
   });
-  const user = useUserStore((state) => state.user);
-  const userName = user?.nickname ?? "회원";
-  //TODO: 렌더링 문제 해결(유저 네임 깜빡임 문제)
+  const { data: userInfo } = useMyPage();
+
+  const userName = userInfo?.username ?? "회원";
 
   const { mutate } = usePostUserType();
   const handleClick = () => {
@@ -55,7 +56,6 @@ export default function Trait() {
 
   const isLastStep = step === 3;
   const buttonText = isLastStep ? "제출하기" : "다음";
-  const nickname = "서현";
 
   return (
     <FormProvider {...methods}>

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -22,7 +22,6 @@ export default function Home() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFirstScreen, setIsFirstScreen] = useState(true);
   useMyPage();
-  console.log("현재 저장된 유저 Store 값:", user);
   useEffect(() => {
     const handleScroll = () => {
       if (!containerRef.current) return;
@@ -145,7 +144,18 @@ export default function Home() {
             </div>
           ))
         )}
-
+        {events.length > 0 && events.length <= 4 && (
+          <div
+            className={
+              {
+                1: "h-105",
+                2: "h-72",
+                3: "h-56",
+                4: "h-40",
+              }[events.length]
+            }
+          />
+        )}
         {events.length === 5 && (
           <Button
             className="mt-1 mb-5"

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -22,7 +22,7 @@ export default function Home() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFirstScreen, setIsFirstScreen] = useState(true);
   useMyPage();
-
+  console.log("현재 저장된 유저 Store 값:", user);
   useEffect(() => {
     const handleScroll = () => {
       if (!containerRef.current) return;

--- a/src/app/_apis/auth/mypage.ts
+++ b/src/app/_apis/auth/mypage.ts
@@ -8,6 +8,7 @@ export interface MyPageResponse {
   hostExperienceCount: number;
   participationExperienceCount: number;
   ticketCount: number;
+  phoneNumber: string;
 }
 
 export const getMyPageInfo = () => {

--- a/src/app/_hooks/auth/use-mypage.ts
+++ b/src/app/_hooks/auth/use-mypage.ts
@@ -19,6 +19,7 @@ export const useMyPage = () => {
           hostExperienceCount: res.hostExperienceCount,
           participationExperienceCount: res.participationExperienceCount,
           ticketCount: res.ticketCount,
+          phoneNumber: res.phoneNumber,
         });
       }
       return res;

--- a/src/app/_stores/useUserStore.ts
+++ b/src/app/_stores/useUserStore.ts
@@ -9,6 +9,7 @@ interface UserProfile {
   hostExperienceCount: number;
   participationExperienceCount: number;
   ticketCount: number;
+  phoneNumber: String;
 }
 
 interface UserState {
@@ -21,7 +22,13 @@ export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
       user: null,
-      setUser: (user) => set({ user }),
+      setUser: (partialUser) =>
+        set((state) => ({
+          user: {
+            ...state.user,
+            ...partialUser,
+          },
+        })),
       clearUser: () => set({ user: null }),
     }),
     {

--- a/src/app/_stores/useUserStore.ts
+++ b/src/app/_stores/useUserStore.ts
@@ -1,16 +1,6 @@
+import { UserProfile } from "app/_types/user-profile";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-
-interface UserProfile {
-  email: string;
-  nickname: string;
-  profileImage: string;
-  userTypeTitle: string;
-  hostExperienceCount: number;
-  participationExperienceCount: number;
-  ticketCount: number;
-  phoneNumber: String;
-}
 
 interface UserState {
   user: UserProfile | null;

--- a/src/app/_types/user-profile.ts
+++ b/src/app/_types/user-profile.ts
@@ -1,0 +1,10 @@
+export interface UserProfile {
+  email: string;
+  nickname: string;
+  profileImage: string;
+  userTypeTitle: string;
+  hostExperienceCount: number;
+  participationExperienceCount: number;
+  ticketCount: number;
+  phoneNumber: String;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
         <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" href="/images/favicon/48x48.png" />
       </head>
       <body>
         <InAppRedirect />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #184 

---
## 📋 작업 상세 내용
-  set-profile에서 마페 api 요청 후 저장, 이후 유형테스트, 홈에서 store값으로 사용
- 연결된 소셜 계정 페이지 UI 구현
- 파비콘 추가 
---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->
![image](https://github.com/user-attachments/assets/19e7e3d4-25c8-4cc3-91c8-359866a6fdb4)
![image](https://github.com/user-attachments/assets/25c7ec40-5484-410c-a080-48a91ebc82b1)


## 📌 앞으로의 작업 (선택)
알림 테스트ㅡㅡㅡㅡㅡㅡ..............

## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User account page now displays the connected Kakao account icon and user email.
  - Added a favicon to the application for improved branding.
  - User profile now includes and displays the user's phone number.

- **Improvements**
  - Enhanced user state management to support partial updates and additional profile fields.
  - Improved user information display and retrieval in various profile and trait-related pages.
  - Adjusted event list layout on the home page for better visual spacing based on event count.

- **Bug Fixes**
  - Resolved potential user name flickering issues on the trait result page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->