### PR TITLE
[Design/#226] 로딩 페이지 및 컴포넌트 분리

### DIFF
--- a/src/app/(fullscreen)/event-create/components/step6-place.tsx
+++ b/src/app/(fullscreen)/event-create/components/step6-place.tsx
@@ -2,12 +2,12 @@
 
 import { StepHeader } from "@/components";
 import { useRecommendedCinemas } from "app/_hooks/use-recommend-cinema";
-import Loading from "app/loading";
 import Image from "next/image";
 import { useFormContext, useWatch } from "react-hook-form";
 import { LocationIcon } from "@/icons/index";
 import { formatPrice } from "@/utils/format-price";
 import { useSelectedCinemaStore } from "app/_stores/use-selected-cinema-store";
+import Loading from "@/components/loading";
 export default function Step6() {
   const { setValue, control } = useFormContext();
   const selectedLocationId = useWatch({ control, name: "locationId" });

--- a/src/app/_components/loading.tsx
+++ b/src/app/_components/loading.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import Lottie from "lottie-react";
+import loadingAnimation from "@/lotties/loading.json";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center">
+      <Lottie animationData={loadingAnimation} loop autoplay />
+    </div>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,17 +1,9 @@
-"use client";
+import Loading from "./_components/loading";
 
-import Lottie from "lottie-react";
-import loadingAnimation from "@/lotties/loading.json";
-
-export default function Loading() {
+export default function LoadingPage() {
   return (
     <div className="relative flex h-screen w-full justify-center">
-      <div
-        className="relative inline-flex flex-col"
-        style={{ paddingTop: "30vh" }}
-      >
-        <Lottie animationData={loadingAnimation} loop autoplay />
-      </div>
+      <Loading />
     </div>
   );
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #226 


## ✅ PR 요약

<!-- 이번 PR에서 변경된 핵심 내용을 간결하게 설명해주세요. -->
- 로딩 페이지 및 컴포넌트 분리

---
## 📋 작업 상세 내용
로딩 페이지와 로딩컴포넌트를 분리하였습니다.

---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->

https://github.com/user-attachments/assets/c0792403-0886-41e4-9981-e80a4fbb7e98



## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->

일단 UX 문제 중 하나인 로딩 처리를 컴포넌트를 분리하여 개선하였는데, 현재 문제점으로 제기한 이벤트 step6는 로딩컴포넌트로 로딩처리를 하는 것이 아닌 스켈레톤 UI를 쓰는 것이 더 합리적이라는 생각이 듭니다!! 논의가 필요할 거 같습니다!
