### PR TITLE
[Bug/#237] notification 필드가 없을 경우 수동알림표시 

### DIFF
--- a/public/custom-sw.js
+++ b/public/custom-sw.js
@@ -13,10 +13,14 @@ const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage((payload) => {
   console.log("📩 Background message received:", payload);
-  self.registration.showNotification(payload.notification.title, {
-    body: payload.notification.body,
-    icon: "/images/favicon/96x96.png",
-  });
+
+  if (!payload.notification) {
+    const { title, body } = payload.data;
+    self.registration.showNotification(title, {
+      body,
+      icon: "/images/favicon/96x96.png",
+    });
+  }
 });
 
 // next-pwa의 워크박스 매니페스트

--- a/src/app/_components/fixed-layout.tsx
+++ b/src/app/_components/fixed-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import Header from "@/components/header";
 import { Button } from "@/components";
 import { cn } from "@/utils/cn";
@@ -34,6 +34,7 @@ export default function FixedLayout({
   state = "default",
   showBottomButton = true,
 }: FixedLayoutProps) {
+  const [hasClicked, setHasClicked] = useState(false);
   const paddingStyle =
     state === "default"
       ? " pt-21.75 px-5"
@@ -42,6 +43,12 @@ export default function FixedLayout({
         : state === "preview"
           ? "pt-15.5 px-0"
           : "p-0";
+
+  const handleClick = () => {
+    if (hasClicked || isButtonDisabled) return;
+    setHasClicked(true);
+    onButtonClick?.();
+  };
 
   return (
     <>
@@ -62,10 +69,10 @@ export default function FixedLayout({
       {showBottomButton && (
         <div className="bg-gray-black fixed bottom-0 z-50 w-full max-w-125 px-5 pt-5 pb-12.5">
           <Button
-            disabled={isButtonDisabled}
-            onClick={onButtonClick}
+            disabled={isButtonDisabled || hasClicked}
+            onClick={handleClick}
             className={cn(
-              isButtonDisabled
+              isButtonDisabled || hasClicked
                 ? "bg-gray-900 text-gray-700"
                 : "bg-red-main text-white",
             )}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #237 

---
## 📋 작업 상세 내용

- 자동 푸시알림 안되면 수동으로 알림 가게끔
- fixed-layout에ㅐ button 중복 방지 
---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
