### PR TITLE
[Refactor/#239] 하단버튼 상태 초기화, 노치 배경확장, pnpm 캐시활용

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+package-manager=pnpm@9.15.0     #Vercel과 로컬 모두 동일한 pnpm 버전을 사용하게 함
+shared-workspace-lockfile=true  #일관된 lockfile 유지로 의존성 문제 방지
+prefer-frozen-lockfile=true     #lockfile 변경 없이 빠르고 예측 가능한 설치
+
+# 불필요한 네트워크 호출 감소 → 의존성 설치 시간 단축

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const withSvgr = require("next-svgr");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   trailingSlash: true,
+  output: "standalone",
   images: {
     remotePatterns: [
       {

--- a/src/app/(fullscreen)/event-create/page.tsx
+++ b/src/app/(fullscreen)/event-create/page.tsx
@@ -114,6 +114,7 @@ export default function EventCreatePage() {
   return (
     <FormProvider {...methods}>
       <FixedLayout
+        key={step}
         title="이벤트 생성"
         onButtonClick={onNext}
         isButtonDisabled={isButtonDisabled}

--- a/src/app/(fullscreen)/event/success/_components/client.tsx
+++ b/src/app/(fullscreen)/event/success/_components/client.tsx
@@ -45,6 +45,7 @@ export default function Client() {
         />
       ) : (
         <FixedLayout
+          step={step}
           buttonText={step === 1 ? "이벤트 미리보기" : "이벤트 게시하기"}
           showCloseButton={true}
           onButtonClick={handleButtonClick}

--- a/src/app/(fullscreen)/intro/page.tsx
+++ b/src/app/(fullscreen)/intro/page.tsx
@@ -2,10 +2,10 @@
 
 import { LogoWhiteIcon } from "@/icons/index";
 
-//TODO: setTimeout 3초
+// TODO: setTimeout 3초
 export default function Intro() {
   return (
-    <main className="relative h-screen w-full bg-[url('/images/custom-bg.png')] bg-cover bg-center">
+    <main className="pt-safe-top relative h-[100dvh] w-full bg-[url('/images/custom-bg.png')] bg-cover bg-center">
       <div className="absolute top-[47.14%] left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
         <div className="flex flex-col items-center">
           <LogoWhiteIcon width={100} height={100} />

--- a/src/app/(fullscreen)/trait/result/page.tsx
+++ b/src/app/(fullscreen)/trait/result/page.tsx
@@ -33,7 +33,7 @@ export default function TraitResult() {
     data?.userTypeCode &&
     PATH_IMAGES.TRAIT[data.userTypeCode as keyof typeof PATH_IMAGES.TRAIT];
   return (
-    <div className="relative flex h-screen w-full items-center justify-center">
+    <div className="pt-safe-top relative flex h-[100dvh] w-full items-center justify-center">
       <Image
         src={PATH_IMAGES.TRAIT.BACKGROUND}
         alt="배경"

--- a/src/app/(tabs)/my-page/page.tsx
+++ b/src/app/(tabs)/my-page/page.tsx
@@ -61,7 +61,10 @@ export default function MyPage() {
       </div>
       <ul className="body-3-medium pl-2 text-gray-100">
         {[
-          { label: "서비스이용약관", onClick: () => router.push(PATHS.TOS) },
+          // { label: "서비스이용약관", onClick: () => router.push(PATHS.TOS) },
+          //TODO: pwa 노치확인 위한 라우터 변경
+          { label: "서비스이용약관", onClick: () => router.push("/intro") },
+
           {
             label: "개인정보처리방침",
             onClick: () => router.push(PATHS.PRIVACY_POLICY),

--- a/src/app/_components/fixed-layout.tsx
+++ b/src/app/_components/fixed-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import Header from "@/components/header";
 import { Button } from "@/components";
 import { cn } from "@/utils/cn";
@@ -18,6 +18,7 @@ type FixedLayoutProps = {
   isHeader?: boolean;
   state?: "default" | "detail" | "full" | "preview";
   showBottomButton?: boolean;
+  step?: number;
 };
 
 export default function FixedLayout({
@@ -33,8 +34,13 @@ export default function FixedLayout({
   isHeader = true,
   state = "default",
   showBottomButton = true,
+  step,
 }: FixedLayoutProps) {
   const [hasClicked, setHasClicked] = useState(false);
+  useEffect(() => {
+    setHasClicked(false);
+  }, [step]);
+
   const paddingStyle =
     state === "default"
       ? " pt-21.75 px-5"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from "tailwindcss";
+import plugin from "tailwindcss/plugin";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        ".pt-safe-top": {
+          paddingTop: "env(safe-area-inset-top)",
+        },
+        ".pb-safe-bottom": {
+          paddingBottom: "env(safe-area-inset-bottom)",
+        },
+      });
+    }),
+  ],
+};
+
+export default config;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #239 

---
## 📋 작업 상세 내용
- 버셀 빌드속도가 너어ㅓㅓ무 느려서 pnpm 캐시활용하는 방법 적용했습니다.
- 중복방지적용했더니 비활성화가 계속되는 문제있어서 수정했고
- 노치 배경확장 하기위해서 config파일 추가했는데 pwa에서 테스트 필요합니다
(intro로 노치확장 적용했는데 지금 intro 안보이게되어있어서 임시로 서비스 약관누르면 보이게 라우터임시수정했습니다)
---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
