### PR TITLE
[Refactor/#245] FCM 알림 구현, 훅 분리, 이중수신 이슈

### DIFF
--- a/public/custom-sw.js
+++ b/public/custom-sw.js
@@ -17,9 +17,14 @@ messaging.onBackgroundMessage((payload) => {
   self.registration.showNotification(title, {
     body,
     icon: "/images/favicon/96x96.png",
+    tag: `event-${eventId}`,
+    // 같은 태그면 알림이 덮어씌워지므로 유사 알림 중복도 막을 수 있음
     data: {
       eventId: payload.data?.eventId,
     },
+    // data: {
+    //   url: `/detail/${payload.data?.eventId}`,
+    // },
   });
 });
 

--- a/public/custom-sw.js
+++ b/public/custom-sw.js
@@ -12,18 +12,14 @@ const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage((payload) => {
   console.log("📩 Background message received:", payload);
-
-  const title =
-    payload.notification?.title || payload.data?.title || "📩 무비부키 알림";
-  const body =
-    payload.notification?.body ||
-    payload.data?.body ||
-    "새로운 알림이 도착했어요!";
   console.log("📬 도착한 Background 알림 내용:", { title, body });
 
   self.registration.showNotification(title, {
     body,
     icon: "/images/favicon/96x96.png",
+    data: {
+      eventId: payload.data?.eventId,
+    },
   });
 });
 
@@ -34,7 +30,29 @@ self.addEventListener("install", (event) => {
   self.skipWaiting();
 });
 
-self.addEventListener("activate", (event) => {
-  console.log("✅ Service Worker activated");
-  event.waitUntil(self.clients.claim());
+self.addEventListener("notificationclick", function (event) {
+  event.notification.close();
+
+  // eventId 전달받기 (tag 또는 data로부터)
+  const eventId = event.notification?.data?.eventId;
+
+  const targetUrl = eventId ? `/detail/${eventId}` : "/"; // fallback
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if (client.url.includes("/") && "focus" in client) {
+            client.navigate(targetUrl);
+            return client.focus();
+          }
+        }
+
+        // 창이 없으면 새로 열기
+        if (clients.openWindow) {
+          return clients.openWindow(targetUrl);
+        }
+      }),
+  );
 });

--- a/public/custom-sw.js
+++ b/public/custom-sw.js
@@ -1,4 +1,3 @@
-// FCM 스크립트
 importScripts(
   "https://www.gstatic.com/firebasejs/10.12.1/firebase-app-compat.js",
 );
@@ -14,7 +13,6 @@ const messaging = firebase.messaging();
 messaging.onBackgroundMessage((payload) => {
   console.log("📩 Background message received:", payload);
 
-  //  notification or data에서 title/body 추출
   const title =
     payload.notification?.title || payload.data?.title || "📩 무비부키 알림";
   const body =
@@ -29,10 +27,8 @@ messaging.onBackgroundMessage((payload) => {
   });
 });
 
-// next-pwa의 워크박스 매니페스트
 self.__WB_MANIFEST;
 
-// 서비스워커 생명주기 관리
 self.addEventListener("install", (event) => {
   console.log("🔧 Service Worker installing...");
   self.skipWaiting();

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -11,8 +11,7 @@ import { useCategoryEvents } from "app/_hooks/events/use-category-events";
 import CardSkeleton from "@/components/card-skeleton";
 import { categoryMap } from "@/constants/category-map";
 import { useMyPage } from "app/_hooks/auth/use-mypage";
-import { useFCM } from "app/_hooks/use-fcm";
-import { useNotificationStore } from "app/_stores/use-noti";
+import { useFCMHandler } from "app/_hooks/fcm/use-fcm-handler";
 
 export default function Home() {
   const user = useUserStore((state) => state.user);
@@ -22,91 +21,13 @@ export default function Home() {
   const [isFirstScreen, setIsFirstScreen] = useState(true);
   const [selected, setSelected] =
     useState<(typeof CATEGORY_LABELS)[number]>("인기");
-  const [showPermissionBanner, setShowPermissionBanner] = useState(false);
-  const { requestPermissionAndToken, onForegroundMessage, getCurrentFCMToken } =
-    useFCM();
+  const {
+    showPermissionBanner,
+    setShowPermissionBanner,
+    requestPermissionAndToken,
+  } = useFCMHandler();
 
   useMyPage();
-
-  //TODO: fcm handler로 분리해야함
-  // useEffect(() => {
-  //   const alreadyRegistered = localStorage.getItem("fcm-registered");
-  //   const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
-  //   const isStandalone = window.matchMedia(
-  //     "(display-mode: standalone)",
-  //   ).matches;
-
-  //   // ✅ Android는 자동 요청, iOS는 클릭 유도
-  //   if (!isIOS && alreadyRegistered !== "true") {
-  //     console.log("📡 Android - 최초 FCM 등록");
-  //     requestPermissionAndToken().then(() => {
-  //       localStorage.setItem("fcm-registered", "true");
-  //     });
-  //   } else {
-  //     console.log("이미 등록된 FCM - 토큰 발급 넘어감");
-  //     getCurrentFCMToken().then((token) => {
-  //       if (token) {
-  //         console.log("📦 기존 기기 FCM 토큰:", token);
-  //       } else {
-  //         console.warn("⚠️ 토큰 없음 또는 실패");
-  //       }
-  //     });
-  //   }
-  useEffect(() => {
-    console.log("🌐 모든 환경에서 FCM 토큰 등록 시도");
-    requestPermissionAndToken();
-
-    // iOS 권한 배너 조건은 유지
-    const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
-    const isStandalone =
-      window.matchMedia("(display-mode: standalone)").matches ||
-      (window.navigator as any).standalone === true;
-
-    if (isIOS && isStandalone && Notification.permission === "default") {
-      console.log("ℹ️ iOS PWA - 알림 권한 배너 표시");
-      setShowPermissionBanner(true);
-    }
-    onForegroundMessage((payload) => {
-      console.log("📩 알림 수신 (fcm handler):", payload);
-
-      const title =
-        payload.notification?.title ||
-        payload.data?.title ||
-        "📩 무비부키 알림";
-      const body =
-        payload.notification?.body ||
-        payload.data?.body ||
-        "새로운 알림이 도착했어요!";
-
-      // ✅ 브라우저 알림 띄우기 (모바일/백그라운드 대응)
-      if (Notification.permission === "granted") {
-        navigator.serviceWorker.ready.then((registration) => {
-          registration.showNotification(title, {
-            body,
-            icon: "/images/favicon/96x96.png",
-            tag: "foreground-noti",
-            renotify: true,
-          } as NotificationOptions);
-        });
-      }
-
-      //  3. 내부 저장소에도 기록 (예: zustand store)
-      const { code, eventId } = payload.data || {};
-      const parsedCode = code ? Number(code) : 99;
-      const parsedEventId = Number(eventId);
-
-      if (!title || !body || !eventId || isNaN(parsedEventId)) return;
-
-      useNotificationStore.getState().addNotification({
-        title,
-        body,
-        code: parsedCode,
-        eventId: parsedEventId,
-      });
-
-      console.log("✅ 알림 저장 완료:", title);
-    });
-  }, []);
 
   // scroll 복원
   useEffect(() => {

--- a/src/app/_components/FCM/ServiceWorkerDebug.tsx
+++ b/src/app/_components/FCM/ServiceWorkerDebug.tsx
@@ -1,4 +1,3 @@
-// app/_components/ServiceWorkerDebug.tsx
 "use client";
 import { useEffect } from "react";
 

--- a/src/app/_hooks/fcm/use-fcm-handler.ts
+++ b/src/app/_hooks/fcm/use-fcm-handler.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { useFCM } from "./use-fcm";
+import { useNotificationStore } from "app/_stores/use-noti";
+
+export const useFCMHandler = () => {
+  const [showPermissionBanner, setShowPermissionBanner] = useState(false);
+  const { requestPermissionAndToken, onForegroundMessage } = useFCM();
+
+  useEffect(() => {
+    console.log("🌐 모든 환경에서 FCM 토큰 등록 시도");
+    requestPermissionAndToken();
+
+    // iOS PWA 권한 배너 표시 조건
+    const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      (window.navigator as any).standalone === true;
+
+    if (isIOS && isStandalone && Notification.permission === "default") {
+      console.log("ℹ️ iOS PWA - 알림 권한 배너 표시");
+      setShowPermissionBanner(true);
+    }
+
+    onForegroundMessage((payload) => {
+      console.log("📩 알림 수신 (fcm handler):", payload);
+
+      const title =
+        payload.notification?.title ||
+        payload.data?.title ||
+        "📩 무비부키 알림";
+      const body =
+        payload.notification?.body ||
+        payload.data?.body ||
+        "새로운 알림이 도착했어요!";
+
+      // foreground 알림
+      if (Notification.permission === "granted") {
+        navigator.serviceWorker.ready.then((registration) => {
+          registration.showNotification(title, {
+            body,
+            icon: "/images/favicon/96x96.png",
+            tag: "foreground-noti",
+            renotify: true,
+          } as NotificationOptions);
+        });
+      }
+
+      const { code, eventId } = payload.data || {};
+      const parsedCode = code ? Number(code) : 99;
+      const parsedEventId = Number(eventId);
+
+      if (!title || !body || !eventId || isNaN(parsedEventId)) return;
+
+      useNotificationStore.getState().addNotification({
+        title,
+        body,
+        code: parsedCode,
+        eventId: parsedEventId,
+      });
+
+      console.log("✅ 알림 저장 완료:", title);
+    });
+  }, []);
+
+  return {
+    showPermissionBanner,
+    setShowPermissionBanner,
+    requestPermissionAndToken,
+  };
+};

--- a/src/app/_hooks/fcm/use-fcm.ts
+++ b/src/app/_hooks/fcm/use-fcm.ts
@@ -1,4 +1,3 @@
-// hooks/useFCM.ts
 import { getToken, onMessage } from "firebase/messaging";
 import { getFirebaseMessaging } from "app/_lib/firebase-config";
 import { registerFCMToken } from "app/_apis/register-fcm-token";
@@ -29,22 +28,6 @@ export const useFCM = () => {
     }
   };
 
-  const getCurrentFCMToken = async () => {
-    try {
-      const messaging = await getFirebaseMessaging();
-      const registration = await navigator.serviceWorker.ready;
-
-      const token = await getToken(messaging!, {
-        vapidKey: process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY!,
-        serviceWorkerRegistration: registration,
-      });
-
-      return token;
-    } catch (err) {
-      console.error("❌ FCM 토큰 가져오기 실패:", err);
-      return null;
-    }
-  };
   const onForegroundMessage = (callback: (payload: any) => void) => {
     getFirebaseMessaging().then((messaging) => {
       console.log("onForegroundMessage 등록");
@@ -57,5 +40,5 @@ export const useFCM = () => {
     });
   };
 
-  return { requestPermissionAndToken, onForegroundMessage, getCurrentFCMToken };
+  return { requestPermissionAndToken, onForegroundMessage };
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #245 

---
## 📋 작업 상세 내용
- fcm 관련 코드분리 
- 아 pc에서 잘되는데 모바일로 알림이 안왔던 이유가 FCM은 계정이 아닌 디바이스의 토큰을 기준으로 알림을 전송함 -> 기존 코드에서는 모바일에서 토큰 등록이 누락되어 알림 수신 불가-> 모든 디바이스에서 FCM 토큰을 재등록하도록 해서 젤최신꺼 덮어써지게함. 
- 알림 두개씩 수신되는거 수정했는데 확인필요
- 
---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->
![image](https://github.com/user-attachments/assets/53134a6a-a920-499f-bf5b-d57eb39880c8)


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->

- [ ] 알림탭 
- [ ] 시스템 알림 클릭시 해당페이지로 잘이동되늦지 확인
- [ ] 노치적용안되서 다시수정해야함 .........

- 백그라운드 알림오면 클릭해서 해당 id detail페이지로 들어갈수 있는데 이렇게되어도 알림탭에 안읽음 표시로 있는게 맞는지....를 기획한테 물어보고 후에 알림탭 작업해야할듯합니다.

## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
