### PR TITLE
[Design/#265] 카카오로그인 에러처리, 생성버튼 추가, 유형결과 페이지 라우터추가 

### DIFF
--- a/src/app/(fullscreen)/category/[category]/client.tsx
+++ b/src/app/(fullscreen)/category/[category]/client.tsx
@@ -3,17 +3,12 @@
 import { useState } from "react";
 import { Card, FixedLayout } from "@/components";
 import Pagination from "@/components/pagination";
-import { PATHS } from "@/constants";
-import { EmptyIcon } from "@/icons/index";
-import { useRouter } from "next/navigation";
-import Loading from "app/loading";
 import { useCategoryPageEvents } from "app/_hooks/events/use-category-events";
 import CardSkeleton from "@/components/card-skeleton";
 
 export default function CategoryPageClient({ label }: { label: string }) {
   const itemsPerPage = 10;
   const [currentPage, setCurrentPage] = useState(0);
-  const router = useRouter();
 
   const { data, isLoading } = useCategoryPageEvents(
     label,
@@ -39,7 +34,7 @@ export default function CategoryPageClient({ label }: { label: string }) {
               <CardSkeleton key={idx} />
             ))}
           </div>
-        ) : cards.length > 0 ? (
+        ) : (
           cards.map((card, idx) => (
             <div key={card.eventId}>
               <Card
@@ -59,20 +54,6 @@ export default function CategoryPageClient({ label }: { label: string }) {
               )}
             </div>
           ))
-        ) : (
-          <div className="mb-80 flex flex-col items-center justify-center pt-30 text-center text-gray-500">
-            <EmptyIcon />
-            <p className="body-3-medium mt-3.5 mb-7 text-gray-800">
-              아직 모집 이벤트가 없어요 <br />
-              지금 바로 나만의 이벤트를 만들어보세요
-            </p>
-            <button
-              onClick={() => router.push(PATHS.EVENT_CREATE)}
-              className="bg-red-main body-3-semibold w-75 rounded-xl px-6 py-4 text-white"
-            >
-              나만의 이벤트 만들러 가기
-            </button>
-          </div>
         )}
       </div>
 

--- a/src/app/(fullscreen)/trait/result/page.tsx
+++ b/src/app/(fullscreen)/trait/result/page.tsx
@@ -3,17 +3,21 @@
 import { Button } from "@/components";
 import { LineBreak } from "@/components/line-break";
 import { PATH_IMAGES, PATHS } from "@/constants/index";
-import { LogoWhiteIcon } from "@/icons/index";
+import { BackIcon, LogoWhiteIcon } from "@/icons/index";
 import { useGetUserTypeResult } from "app/_hooks/use-user-type";
 import { useUserStore } from "app/_stores/use-user-store";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { USER_TYPE_ICONS } from "@/constants/user-type-icon";
+import { useSearchParams, useRouter } from "next/navigation";
 
 export default function TraitResult() {
   const [isShortScreen, setIsShortScreen] = useState(false); // ← 초기값 false
+  const searchParams = useSearchParams();
   const router = useRouter();
+  const from = searchParams.get("from");
+
+  const isFromMyPage = from === "mypage";
 
   const handleClick = () => {
     router.push(PATHS.HOME);
@@ -52,20 +56,41 @@ export default function TraitResult() {
 
   return (
     <div className="relative grid min-h-screen w-full grid-rows-[auto_1fr_auto] overflow-hidden bg-black">
+      {isFromMyPage && (
+        <div className="absolute top-5 left-5 z-50">
+          <button onClick={() => router.back()} className="text-white">
+            ←
+          </button>
+          <button
+            className="absolute top-2.5 left-2.5"
+            onClick={() => router.back()}
+            aria-label="뒤로가기"
+            type="button"
+          >
+            <BackIcon className="h-full w-full" />
+          </button>
+        </div>
+      )}
+
       <div
-        className={`flex justify-center ${isShortScreen ? "mt-8" : "mt-20"}`}
+        className={`flex justify-center ${
+          isShortScreen ? "mt-8" : isFromMyPage ? "mt-32" : "mt-20"
+        }`}
       >
         <div className="rounded-full bg-gray-900 px-5 py-1.5 text-gray-200">
           무비부키 유형 테스트
         </div>
       </div>
       <div className="flex items-start justify-center">
-        <div
-          className="relative mt-8 h-[460px] w-[320px] overflow-hidden rounded-[20px] bg-cover bg-center shadow-lg"
-          style={{
-            backgroundImage: `url(${PATH_IMAGES.TRAIT.BACKGROUND})`,
-          }}
-        >
+        <div className="relative mt-8 h-[460px] w-[320px] overflow-hidden rounded-[20px] shadow-lg">
+          <Image
+            src={PATH_IMAGES.TRAIT.BACKGROUND}
+            alt="배경 이미지"
+            fill
+            priority
+            className="object-cover"
+            sizes="320px"
+          />
           <div className="absolute inset-0 z-0 bg-[rgba(255,255,255,0.1)]" />
           <div className="relative z-10 flex h-full flex-col items-center px-6 pt-11">
             <p className="body-2-medium text-red-100">{data?.username}님은</p>
@@ -107,9 +132,11 @@ export default function TraitResult() {
         </div>
       </div>
 
-      <div className="fixed bottom-0 z-50 w-full max-w-125 px-5 pt-5 pb-12">
-        <Button onClick={handleClick}>무비부키 시작하기</Button>
-      </div>
+      {!isFromMyPage && (
+        <div className="fixed bottom-0 z-50 w-full max-w-125 px-5 pt-5 pb-12">
+          <Button onClick={handleClick}>무비부키 시작하기</Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -150,12 +150,18 @@ export default function Home() {
               ))}
             </div>
           ) : events.length === 0 ? (
-            <div className="mb-78 flex flex-col items-center justify-center pt-30 text-center text-gray-500">
+            <div className="mb-80 flex flex-col items-center justify-center pt-30 text-center text-gray-500">
               <EmptyIcon />
-              <p className="body-3-medium mt-3.5 text-gray-800">
+              <p className="body-3-medium mt-3.5 mb-7 text-gray-800">
                 아직 모집 이벤트가 없어요 <br />
                 지금 바로 나만의 이벤트를 만들어보세요
               </p>
+              <button
+                onClick={() => router.push(PATHS.EVENT_CREATE)}
+                className="bg-red-main body-3-semibold w-75 rounded-xl px-6 py-4 text-white"
+              >
+                나만의 이벤트 만들러 가기
+              </button>
             </div>
           ) : (
             events.map((event) => (

--- a/src/app/(tabs)/my-page/page.tsx
+++ b/src/app/(tabs)/my-page/page.tsx
@@ -4,8 +4,8 @@ import Modal from "@/components/modal";
 import { PATHS } from "@/constants";
 import { ArrowRightIcon, DefaultProfileIcon, MyKakaoIcon } from "@/icons/index";
 import { useLogout, useLogoutHandler } from "app/_hooks/auth/use-logout";
-import { useToastStore } from "app/_stores/use-toast-store";
 import { useUserStore } from "app/_stores/use-user-store";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 interface MyPageStatProps {
@@ -31,24 +31,36 @@ export default function MyPage() {
   return (
     <div className="h-[calc(100vh-102px)] overflow-y-scroll px-5 text-white">
       <h1 className="title-1-semibold pt-6 pb-7.5">마이페이지</h1>
-      <div className="mb-5 flex items-center gap-4">
-        <div className="border-red-main flex h-20 w-20 items-center justify-center rounded-full border-2">
-          {user?.profileImage ? (
-            <img
-              src={user.profileImage}
-              alt="프로필"
-              className="h-18 w-18 rounded-full"
-            />
-          ) : (
-            <DefaultProfileIcon className="h-18 w-18 rounded-full" />
-          )}
+      <div
+        className="mb-5 flex cursor-pointer items-center justify-between gap-4"
+        onClick={() => router.push(`${PATHS.TRAIT_RESULT}?from=mypage`)}
+        role="button"
+      >
+        <div className="flex items-center gap-4">
+          <div className="border-red-main flex h-20 w-20 items-center justify-center rounded-full border-2">
+            {user?.profileImage ? (
+              <Image
+                src={user.profileImage}
+                alt="프로필"
+                width={72}
+                height={72}
+                className="rounded-full"
+                priority
+              />
+            ) : (
+              <DefaultProfileIcon className="h-18 w-18 rounded-full" />
+            )}
+          </div>
+          <div>
+            <p className="text-lg font-semibold">{user?.nickname}</p>
+            <p className="body-3-medium text-gray-500">{user?.userTypeTitle}</p>
+            <p className="caption-1-medium text-gray-500">{user?.email}</p>
+          </div>
         </div>
-        <div>
-          <p className="text-lg font-semibold">{user?.nickname}</p>
-          <p className="body-3-medium text-gray-500">{user?.userTypeTitle}</p>
-          <p className="caption-1-medium text-gray-500">{user?.email}</p>
-        </div>
+
+        <ArrowRightIcon size={16} className="mr-2 text-gray-400" />
       </div>
+
       <div className="flex justify-center">
         <div className="mb-3 flex h-21.75 w-full justify-around rounded-xl bg-gray-950 text-center">
           <MyPageStat label="모집경험" value={user?.hostExperienceCount} />

--- a/src/app/_components/fixed-layout.tsx
+++ b/src/app/_components/fixed-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode } from "react";
 import Header from "@/components/header";
 import { Button } from "@/components";
 import { cn } from "@/utils/cn";

--- a/src/app/_hooks/onboarding/use-kakao-login.ts
+++ b/src/app/_hooks/onboarding/use-kakao-login.ts
@@ -10,12 +10,34 @@ const sendAuthCodeToServer = async ({
   redirectUri: string;
   isLocal: boolean;
 }) => {
-  const response = await axios.get("/api/auth/login/kakao", {
-    params: { code, redirectUri, isLocal },
-    withCredentials: true,
-  });
-  return response.data;
+  try {
+    const response = await axios.get("/api/auth/login/kakao", {
+      params: { code, redirectUri, isLocal },
+      withCredentials: true,
+    });
+    console.log("로그인 성공 응답:", response.data);
+
+    return {
+      success: true,
+      data: response.data,
+    };
+  } catch (error: any) {
+    console.error(
+      " 로그인 에러:",
+      error.response?.status,
+      error.response?.data,
+    );
+
+    return {
+      success: false,
+      message:
+        error?.response?.data?.message ||
+        error.message ||
+        "로그인 중 오류가 발생했습니다.",
+    };
+  }
 };
+
 export const useKakaoLogin = () => {
   return useMutation({
     mutationFn: sendAuthCodeToServer,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #265

---
## 📋 작업 상세 내용

- "App Router에서 useEffect() 안의 await kakaoLogin()에서 throw된 에러는:
try...catch에서 잡고 router.push("/login?error=...")로 보내려 하지만
동시에 Next.js의 전역 error boundary (app/error.tsx) 도 발동하여 /error 페이지가 렌더링됩니다
즉, error.tsx가 자동 발동하고 있음 throw하면 Next.js 에러 바운더리가 잡는다"........라고 해서 throw 대신 return 처리하도록 수정했습니다 

- 카테고리 페이지에 생성 버튼 추가했고
- 마이페이지에서 유형결과 페이지 이동하게했습니다.
---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->

랜딩 개발 시작

## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
- pm이 생성이 안되어서 상세 확인할 수 없다해서 일단 로그인문제를 해결해야할 것같은데 이것도.. 정상되는지 확인필요
