### PR TITLE
[Bug/#286] 이벤트탭 무한스크롤 해결, QA 반영

### DIFF
--- a/src/app/(fullscreen)/event-create/components/step5-people.tsx
+++ b/src/app/(fullscreen)/event-create/components/step5-people.tsx
@@ -156,7 +156,7 @@ export default function Step5({ onValidityChange }: Step5Props) {
       {showToast && (
         <div
           className={`fixed ${
-            isInputFocused ? "bottom-[200px]" : "bottom-32"
+            isInputFocused ? "bottom-[320px]" : "bottom-32"
           } left-1/2 z-50 -translate-x-1/2 transform transition-all duration-300`}
         >
           <Toast iconType="alert">{toastMessage}</Toast>

--- a/src/app/(fullscreen)/feedback/result/components/feedbackpage.tsx
+++ b/src/app/(fullscreen)/feedback/result/components/feedbackpage.tsx
@@ -39,7 +39,7 @@ export default function FeedbackPage() {
       {
         onSuccess: () => {
           showToast("무비부키에게 소중한 의견 감사드려요!", "checkbox");
-          router.push(PATHS.NOTIFICATIONS);
+          router.push(PATHS.MYPAGE);
         },
         onError: (error) => {
           console.error("제출 실패", error);

--- a/src/app/(tabs)/event/_components/event-tabs.tsx
+++ b/src/app/(tabs)/event/_components/event-tabs.tsx
@@ -51,7 +51,7 @@ export default function EventTab({ type }: EventTabProps) {
         onSelect={(selected) => setSelectedToggle(selected as ToggleType)}
       />
 
-      <div className="mt-6 flex flex-col">
+      <div className="overflow-anchor-none mt-6 flex flex-col">
         {isLoading ? (
           <div className="mt-2 flex flex-col gap-4">
             {Array.from({ length: 4 }).map((_, idx) => (
@@ -63,38 +63,32 @@ export default function EventTab({ type }: EventTabProps) {
           </div>
         ) : events.length > 0 ? (
           <>
-            {[...events]
-              .sort(
-                (a, b) =>
-                  new Date(b.eventDate).getTime() -
-                  new Date(a.eventDate).getTime(),
-              )
-              .map((event, index) => (
-                <div
-                  key={event.eventId}
-                  ref={index === events.length - 1 ? lastEventElementRef : null}
-                >
-                  <Card
-                    id={event.eventId}
-                    imageUrl={event.posterImageUrl}
-                    category={event.mediaType}
-                    title={event.mediaTitle}
-                    placeAndDate={`${event.locationName} · ${event.eventDate}`}
-                    description={event.description}
-                    ddayBadge={
-                      event.d_day !== null ? `D-${event.d_day}` : undefined
-                    }
-                    statusBadge={event.eventStatus}
-                    progressRate={
-                      event.rate !== undefined ? `${event.rate}%` : undefined
-                    }
-                    estimatedPrice={event.estimatedPrice}
-                  />
-                  {index < events.length - 1 && (
-                    <div className="my-4 h-px w-full bg-gray-950" />
-                  )}
-                </div>
-              ))}
+            {events.map((event, index) => (
+              <div
+                key={event.eventId}
+                ref={index === events.length - 1 ? lastEventElementRef : null}
+              >
+                <Card
+                  id={event.eventId}
+                  imageUrl={event.posterImageUrl}
+                  category={event.mediaType}
+                  title={event.mediaTitle}
+                  placeAndDate={`${event.locationName} · ${event.eventDate}`}
+                  description={event.description}
+                  ddayBadge={
+                    event.d_day !== null ? `D-${event.d_day}` : undefined
+                  }
+                  statusBadge={event.eventStatus}
+                  progressRate={
+                    event.rate !== undefined ? `${event.rate}%` : undefined
+                  }
+                  estimatedPrice={event.estimatedPrice}
+                />
+                {index < events.length - 1 && (
+                  <div className="my-4 h-px w-full bg-gray-950" />
+                )}
+              </div>
+            ))}
           </>
         ) : (
           <div className="flex flex-col items-center justify-center pt-11 text-center text-gray-900">

--- a/src/app/(tabs)/event/_components/event-tabs.tsx
+++ b/src/app/(tabs)/event/_components/event-tabs.tsx
@@ -6,6 +6,7 @@ import { EmptyIcon } from "@/icons/index";
 import { EVENT_TOGGLES, ToggleType } from "@/constants/event-tab";
 import { useInfiniteEventTabQuery } from "app/_hooks/events/use-event-tab-query";
 import CardSkeleton from "@/components/card-skeleton";
+import { EventCard } from "app/_types/card";
 
 interface EventTabProps {
   type: "신청 목록" | "내 이벤트";
@@ -39,7 +40,8 @@ export default function EventTab({ type }: EventTabProps) {
     [isLoading, hasNextPage, isFetchingNextPage, fetchNextPage],
   );
 
-  const events = data?.pages.flatMap((page) => page) ?? [];
+  const events: EventCard[] =
+    data?.pages.flatMap((page) => (Array.isArray(page) ? page : [])) ?? [];
 
   return (
     <div className="mt-5">
@@ -93,12 +95,6 @@ export default function EventTab({ type }: EventTabProps) {
                   )}
                 </div>
               ))}
-
-            {isFetchingNextPage && (
-              <div className="flex justify-center py-4">
-                <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"></div>
-              </div>
-            )}
           </>
         ) : (
           <div className="flex flex-col items-center justify-center pt-11 text-center text-gray-900">

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -56,6 +56,17 @@ export default function Home() {
     return () => el?.removeEventListener("scroll", handleScroll);
   }, []);
 
+  //스크롤 내려진 페이지 "/?to=list"
+  useEffect(() => {
+    const el = containerRef.current;
+    const toList = searchParams.get("to") === "list";
+    if (el && toList) {
+      const screenHeight = window.innerHeight;
+      requestAnimationFrame(() => {
+        el.scrollTo({ top: screenHeight, behavior: "smooth" });
+      });
+    }
+  }, [searchParams]);
   const getCategoryParam = (label: CategoryLabel) => {
     if (label === "그 외") return "기타";
     return label;

--- a/src/app/_hooks/events/use-event-tab-query.ts
+++ b/src/app/_hooks/events/use-event-tab-query.ts
@@ -1,32 +1,28 @@
-import { TOGGLE_TO_TYPE, ToggleLabel } from "@/constants/event-tab";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import {
   getHostedEvents,
   getRegisteredEvents,
 } from "app/_apis/events/participation";
+import { TOGGLE_TO_TYPE, ToggleLabel } from "@/constants/event-tab";
+import { EventCard } from "app/_types/card";
 
 export function useInfiniteEventTabQuery(
   type: "신청 목록" | "내 이벤트",
   selectedToggle: ToggleLabel,
 ) {
-  const queryFn = type === "신청 목록" ? getRegisteredEvents : getHostedEvents;
+  const fetcher = type === "신청 목록" ? getRegisteredEvents : getHostedEvents;
 
-  return useInfiniteQuery({
+  return useInfiniteQuery<EventCard[], Error>({
     queryKey: [type, selectedToggle, "infinite"],
     queryFn: ({ pageParam = 0 }) =>
-      queryFn({
+      fetcher({
         type: TOGGLE_TO_TYPE[selectedToggle],
-        page: pageParam,
+        page: pageParam as number,
         size: 10,
       }),
     getNextPageParam: (lastPage, allPages) => {
-      if (!lastPage || lastPage.length < 10) {
-        return undefined;
-      }
-      return allPages.length;
+      return lastPage.length === 10 ? allPages.length : undefined;
     },
     initialPageParam: 0,
-    staleTime: 0,
-    refetchOnMount: true,
   });
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,7 +46,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       </head>
       <body>
         <ToastProvider>
-          <DebugLogger />
+          {/* <DebugLogger /> */}
           <Script
             src="https://developers.kakao.com/sdk/js/kakao.js"
             strategy="beforeInteractive"


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #286 

---
## 📋 작업 상세 내용
- 이벤트탭 내이벤트 무한스크롤 안되던거 해결
- QA) 피드백 이후 라우터 마이페이지로 변경
- 홈에서 스크롤 내려진 페이지 "/?to=list"로 접근가능
- 상단 로그보기 버튼 비활성화

---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
