### PR TITLE
[Refactor/#304] home 캐러셀 수정, 성능 최적화, 유형결과 캐싱

### DIFF
--- a/src/app/(fullscreen)/trait/result/page.tsx
+++ b/src/app/(fullscreen)/trait/result/page.tsx
@@ -39,11 +39,15 @@ export default function TraitResult() {
       setIsShortScreen(window.innerHeight < 700);
     };
 
-    if (typeof window !== "undefined") {
-      handleResize();
+    handleResize();
+    const debounced = setTimeout(() => {
       window.addEventListener("resize", handleResize);
-      return () => window.removeEventListener("resize", handleResize);
-    }
+    }, 100);
+
+    return () => {
+      clearTimeout(debounced);
+      window.removeEventListener("resize", handleResize);
+    };
   }, []);
 
   const iconSet =

--- a/src/app/(tabs)/event/_components/event-banner-section.tsx
+++ b/src/app/(tabs)/event/_components/event-banner-section.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { PopcornIcon } from "@/icons/index";
+import { useRouter } from "next/navigation";
+import { PATHS } from "@/constants";
+import Image from "next/image";
+
+export default function EventBannerSection() {
+  const router = useRouter();
+
+  return (
+    <section className="relative mx-5 overflow-hidden rounded-3xl">
+      <Image
+        src="/images/event-banner.webp"
+        alt="이벤트 배너"
+        fill
+        priority
+        className="object-cover"
+      />
+      <div className="relative z-10 flex flex-col items-center px-5 py-8 text-center text-white">
+        <PopcornIcon className="mb-3 h-11 w-11 rotate-[-15.59deg]" />
+        <p className="title-3-semibold leading-snug">
+          지금, 같이 보고 싶은 <br /> 콘텐츠가 있다면?
+        </p>
+        <button
+          onClick={() => router.push(PATHS.EVENT_CREATE)}
+          className="bg-red-main body-3-semibold mt-5 rounded-xl px-6 py-3 text-white focus:bg-red-700"
+        >
+          나만의 이벤트 만들러 가기
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(tabs)/event/page.tsx
+++ b/src/app/(tabs)/event/page.tsx
@@ -4,9 +4,15 @@ import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { PATHS } from "@/constants/index";
 import { PlusIcon } from "lucide-react";
-import { PopcornIcon } from "@/icons/index";
-import Image from "next/image";
+import { Suspense } from "react";
 
+const EventBannerSection = dynamic(
+  () => import("./_components/event-banner-section"),
+  {
+    ssr: false,
+    loading: () => null,
+  },
+);
 const EventTab = dynamic(() => import("./_components/event-tabs"));
 const TicketTab = dynamic(() => import("./_components/ticket-tab"));
 
@@ -19,29 +25,9 @@ export default function EventPage() {
   return (
     <div className="scrollbar-hide relative h-[calc(100vh-102px)] overflow-y-scroll pb-25.5 text-white">
       <h1 className="title-1-semibold px-5 pt-6 pb-5">이벤트</h1>
-      <section className="relative mx-5 overflow-hidden rounded-3xl">
-        <Image
-          src="/images/event-banner.webp"
-          alt="이벤트 배너"
-          fill
-          priority
-          className="object-cover"
-        />
-
-        <div className="relative z-10 flex flex-col items-center px-5 py-8 text-center text-white">
-          <PopcornIcon className="mb-3 h-11 w-11 rotate-[-15.59deg]" />
-          <p className="title-3-semibold leading-snug">
-            지금, 같이 보고 싶은 <br /> 콘텐츠가 있다면?
-          </p>
-          <button
-            onClick={() => router.push(PATHS.EVENT_CREATE)}
-            className="bg-red-main body-3-semibold mt-5 rounded-xl px-6 py-3 text-white focus:bg-red-700"
-          >
-            나만의 이벤트 만들러 가기
-          </button>
-        </div>
-      </section>
-
+      <Suspense fallback={null}>
+        <EventBannerSection />
+      </Suspense>
       <nav className="body-2-medium px-5 pt-6">
         {[
           { label: "신청 목록", value: "apply" },

--- a/src/app/(tabs)/home/_components/carousel.tsx
+++ b/src/app/(tabs)/home/_components/carousel.tsx
@@ -58,7 +58,7 @@ export default function Carousel() {
         {Array.isArray(events) && events.length > 0 ? (
           events.map((event) => (
             <SwiperSlide
-              style={{ width: "282px", height: "404px" }}
+              style={{ width: "260px", height: "373px" }}
               key={event.eventId}
               className="flex items-center rounded-[12px] transition-transform duration-300 ease-in-out"
               onClick={() => router.push(PATHS.EVENT_DETAIL(event.eventId))}
@@ -66,8 +66,8 @@ export default function Carousel() {
               <div className="relative flex h-full w-full items-center justify-center rounded-[12px]">
                 <div className="relative h-full w-full rounded-xl">
                   <Image
-                    width={282}
-                    height={404}
+                    width={260}
+                    height={373}
                     src={event.posterImageUrl}
                     alt={event.title}
                     className="absolute h-full w-full rounded-[12px] object-cover"

--- a/src/app/(tabs)/home/_components/empty-carousel.tsx
+++ b/src/app/(tabs)/home/_components/empty-carousel.tsx
@@ -12,7 +12,7 @@ export default function EmptyCarousel() {
         <div className="h-full w-full rounded-xl bg-[#2A2A2A]" />
       </div>
 
-      <div className="relative z-10 -mx-3 h-101 w-70.5 scale-100 overflow-hidden rounded-xl text-center text-white opacity-100">
+      <div className="h-93.2 relative z-10 -mx-3 w-65 scale-100 overflow-hidden rounded-xl text-center text-white opacity-100">
         <Image
           src="/images/empty-home.png"
           alt="empty home"

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { motion } from "framer-motion";
 import { PATHS, CATEGORY_LABELS } from "@/constants";
@@ -23,6 +23,7 @@ export default function Home() {
   const user = useUserStore((state) => state.user);
   const searchParams = useSearchParams();
   const containerRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
 
   const category = searchParams.get("category");
   const defaultCategory =
@@ -101,20 +102,22 @@ export default function Home() {
         </div>
         <Carousel />
 
-        <motion.div
-          className="from-gray-black/0 to-gray-black pointer-events-none fixed bottom-0 z-5 mb-25.5 flex w-auto flex-col items-center gap-1.25 bg-gradient-to-b from-0% to-50% pt-14.25 pb-3"
-          initial={{ opacity: 1 }}
-          animate={{
-            opacity: isFirstScreen ? 1 : 0,
-            display: isFirstScreen ? "flex" : "none",
-          }}
-          transition={{ duration: 0 }}
-        >
-          <p className="caption-2-medium text-gray-white w-auto opacity-47">
-            더 많은 이벤트를 찾으려면 아래로 스와이프
-          </p>
-          <SwipeDownIcon className="h-6 w-6" />
-        </motion.div>
+        {(pathname === "/" || pathname === "/home") && (
+          <motion.div
+            className="pointer-events-none fixed bottom-0 z-5 mb-20 flex w-auto flex-col items-center gap-1.25 bg-gradient-to-b from-0% to-50% pt-14.25 pb-3"
+            initial={{ opacity: 1 }}
+            animate={{
+              opacity: isFirstScreen ? 1 : 0,
+              display: isFirstScreen ? "flex" : "none",
+            }}
+            transition={{ duration: 0 }}
+          >
+            <p className="caption-2-medium text-gray-white w-auto opacity-25">
+              더 많은 이벤트를 찾으려면 아래로 스와이프
+            </p>
+            <SwipeDownIcon className="h-6 w-6" />
+          </motion.div>
+        )}
       </section>
 
       <motion.section
@@ -125,7 +128,7 @@ export default function Home() {
       >
         <div className="z-0 flex flex-col items-center gap-1.75 pt-6.5 pb-9.75">
           <SwipeDownIcon className="h-6 w-6 rotate-180" />
-          <p className="caption-1-medium text-gray-white opacity-25">
+          <p className="caption-2-medium text-gray-white opacity-25">
             맞춤 이벤트 추천은 위로 스와이프
           </p>
         </div>

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -94,7 +94,7 @@ export default function Home() {
       className="scrollbar-hide title-1-bold h-[calc(100vh-102px)] snap-y snap-mandatory snap-start overflow-y-scroll scroll-smooth"
     >
       <section className="flex h-screen snap-start flex-col items-center overflow-x-hidden pt-15.75">
-        <div className="mb-7 flex flex-col items-center">
+        <div className="mb-5 flex flex-col items-center">
           <p className="body-3-medium text-gray-300">{user?.userTypeTitle}</p>
           <h2 className="title-1-bold text-gray-white mt-0.75">
             {user?.nickname || "회원"}님을 위한 추천
@@ -174,7 +174,7 @@ export default function Home() {
             </button>
           </div>
         ) : (
-          events.map((event) => (
+          events.slice(0, 5).map((event) => (
             <div key={event.eventId}>
               <Card
                 id={String(event.eventId)}
@@ -207,7 +207,7 @@ export default function Home() {
           />
         )}
 
-        {events.length === 5 && (
+        {events.length > 5 && (
           <Button
             className="mt-5 mb-5"
             variant="secondary"

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -1,40 +1,47 @@
 "use client";
 
-import { EmptyIcon, SwipeDownIcon } from "@/icons/index";
 import { useEffect, useRef, useState } from "react";
-import { motion } from "framer-motion";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Button, Card, Input, Carousel } from "@/components";
+import dynamic from "next/dynamic";
+import { motion } from "framer-motion";
 import { PATHS, CATEGORY_LABELS } from "@/constants";
-import { useUserStore } from "app/_stores/use-user-store";
-import { useCategoryEvents } from "app/_hooks/events/use-category-events";
-import CardSkeleton from "@/components/card-skeleton";
 import { categoryMap } from "@/constants/category-map";
+import { useUserStore } from "app/_stores/use-user-store";
 import { useMyPage } from "app/_hooks/auth/use-mypage";
 import { useFCMHandler } from "app/_hooks/fcm/use-fcm-handler";
-import { CategoryLabel } from "@/constants/categories";
+import { useCategoryEvents } from "app/_hooks/events/use-category-events";
+import { EmptyIcon, SwipeDownIcon } from "@/icons/index";
+
+const Button = dynamic(() => import("@/components/button"));
+const Card = dynamic(() => import("@/components/main-card"));
+const Input = dynamic(() => import("@/components/input"));
+const Carousel = dynamic(() => import("./_components/carousel"));
+const CardSkeleton = dynamic(() => import("@/components/card-skeleton"));
 
 export default function Home() {
-  const user = useUserStore((state) => state.user);
   const router = useRouter();
+  const user = useUserStore((state) => state.user);
   const searchParams = useSearchParams();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [isFirstScreen, setIsFirstScreen] = useState(true);
-  const category = searchParams.get("category");
-  const [selected, setSelected] = useState<(typeof CATEGORY_LABELS)[number]>(
-    () =>
-      CATEGORY_LABELS.find((label) => categoryMap[label] === category) ??
-      "인기",
-  );
-  const { requestOnceIfNeeded } = useFCMHandler();
 
+  const category = searchParams.get("category");
+  const defaultCategory =
+    CATEGORY_LABELS.find((label) => categoryMap[label] === category) ?? "인기";
+
+  const [selected, setSelected] =
+    useState<(typeof CATEGORY_LABELS)[number]>(defaultCategory);
+
+  const [fetchedCategories, setFetchedCategories] = useState<
+    (typeof CATEGORY_LABELS)[number][]
+  >(["인기", "최신"]);
+
+  const [isFirstScreen, setIsFirstScreen] = useState(true);
+  const { requestOnceIfNeeded } = useFCMHandler();
   useMyPage();
 
-  // scroll 복원
   useEffect(() => {
     const scrollY = sessionStorage.getItem("homeScrollY");
     const fromSearch = searchParams.get("to") === "category";
-
     if (scrollY && fromSearch) {
       const el = containerRef.current;
       requestAnimationFrame(() => {
@@ -43,32 +50,31 @@ export default function Home() {
     }
   }, [searchParams]);
 
-  // scroll 감지
   useEffect(() => {
     const handleScroll = () => {
       const el = containerRef.current;
       if (!el) return;
       const scrollTop = el.scrollTop;
       const screenHeight = window.innerHeight;
-
       setIsFirstScreen(scrollTop < screenHeight * 0.3);
       sessionStorage.setItem("homeScrollY", String(scrollTop));
     };
-
     const el = containerRef.current;
     el?.addEventListener("scroll", handleScroll);
     return () => el?.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const { data, isLoading } = useCategoryEvents(selected);
-  const events = data?.eventList ?? [];
+  const { data, isLoading } = useCategoryEvents(selected, {
+    enabled: fetchedCategories.includes(selected),
+  });
 
-  const handleSearch = () => {
-    router.push(PATHS.SEARCH);
-  };
+  const events = data?.eventList ?? [];
 
   const handleCategoryClick = (label: (typeof CATEGORY_LABELS)[number]) => {
     setSelected(label);
+    if (!fetchedCategories.includes(label)) {
+      setFetchedCategories((prev) => [...prev, label]);
+    }
   };
 
   useEffect(() => {
@@ -77,143 +83,142 @@ export default function Home() {
     }
   }, [user?.email]);
 
+  const handleSearch = () => {
+    router.push(PATHS.SEARCH);
+  };
+
   return (
-    <>
-      <div
-        ref={containerRef}
-        className="scrollbar-hide title-1-bold h-[calc(100vh-102px)] snap-y snap-mandatory snap-start overflow-y-scroll scroll-smooth"
-      >
-        <section className="flex h-screen snap-start flex-col items-center overflow-x-hidden pt-15.75">
-          <div className="mb-7 flex flex-col items-center">
-            <p className="body-3-medium text-gray-300">{user?.userTypeTitle}</p>
-            <h2 className="title-1-bold text-gray-white mt-0.75">
-              {user?.nickname || "회원"}님을 위한 추천
-            </h2>
-          </div>
-          <Carousel />
+    <div
+      ref={containerRef}
+      className="scrollbar-hide title-1-bold h-[calc(100vh-102px)] snap-y snap-mandatory snap-start overflow-y-scroll scroll-smooth"
+    >
+      <section className="flex h-screen snap-start flex-col items-center overflow-x-hidden pt-15.75">
+        <div className="mb-7 flex flex-col items-center">
+          <p className="body-3-medium text-gray-300">{user?.userTypeTitle}</p>
+          <h2 className="title-1-bold text-gray-white mt-0.75">
+            {user?.nickname || "회원"}님을 위한 추천
+          </h2>
+        </div>
+        <Carousel />
 
-          <motion.div
-            className="from-gray-black/0 to-gray-black pointer-events-none fixed bottom-0 z-5 mb-25.5 flex w-auto flex-col items-center gap-1.25 bg-gradient-to-b from-0% to-50% pt-14.25 pb-3"
-            initial={{ opacity: 1 }}
-            animate={{
-              opacity: isFirstScreen ? 1 : 0,
-              display: isFirstScreen ? "flex" : "none",
-            }}
-            transition={{ duration: 0 }}
-          >
-            <p className="caption-2-medium text-gray-white w-auto opacity-47">
-              더 많은 이벤트를 찾으려면 아래로 스와이프
-            </p>
-            <SwipeDownIcon className="h-6 w-6" />
-          </motion.div>
-        </section>
-
-        <motion.section
-          initial={{ opacity: 0 }}
-          animate={{ opacity: isFirstScreen ? 0 : 1 }}
-          transition={{ duration: 0.6 }}
-          className="flex snap-start flex-col px-5"
+        <motion.div
+          className="from-gray-black/0 to-gray-black pointer-events-none fixed bottom-0 z-5 mb-25.5 flex w-auto flex-col items-center gap-1.25 bg-gradient-to-b from-0% to-50% pt-14.25 pb-3"
+          initial={{ opacity: 1 }}
+          animate={{
+            opacity: isFirstScreen ? 1 : 0,
+            display: isFirstScreen ? "flex" : "none",
+          }}
+          transition={{ duration: 0 }}
         >
-          <div className="z-0 flex flex-col items-center gap-1.75 pt-6.5 pb-9.75">
-            <SwipeDownIcon className="h-6 w-6 rotate-180" />
-            <p className="caption-1-medium text-gray-white opacity-25">
-              맞춤 이벤트 추천은 위로 스와이프
-            </p>
-          </div>
+          <p className="caption-2-medium text-gray-white w-auto opacity-47">
+            더 많은 이벤트를 찾으려면 아래로 스와이프
+          </p>
+          <SwipeDownIcon className="h-6 w-6" />
+        </motion.div>
+      </section>
 
-          <Input type="BUTTON" onClick={handleSearch} />
+      <motion.section
+        initial={{ opacity: 0 }}
+        animate={{ opacity: isFirstScreen ? 0 : 1 }}
+        transition={{ duration: 0.6 }}
+        className="flex snap-start flex-col px-5"
+      >
+        <div className="z-0 flex flex-col items-center gap-1.75 pt-6.5 pb-9.75">
+          <SwipeDownIcon className="h-6 w-6 rotate-180" />
+          <p className="caption-1-medium text-gray-white opacity-25">
+            맞춤 이벤트 추천은 위로 스와이프
+          </p>
+        </div>
 
-          <div className="scrollbar-hide mt-3 -mr-4 mb-4 flex overflow-x-auto whitespace-nowrap">
-            {CATEGORY_LABELS.map((label) => (
-              <div key={label} className="flex items-center">
-                <button
-                  className={`body-2-semibold rounded-full px-3.5 py-2.25 ${
-                    selected === label ? "text-red-main" : "text-gray-500"
-                  }`}
-                  onClick={() => handleCategoryClick(label)}
-                >
-                  {label}
-                </button>
-                {label === "최신" && (
-                  <div className="mx-2 h-4 w-px bg-gray-800" />
-                )}
-              </div>
+        <Input type="BUTTON" onClick={handleSearch} />
+
+        <div className="scrollbar-hide mt-3 -mr-4 mb-4 flex overflow-x-auto whitespace-nowrap">
+          {CATEGORY_LABELS.map((label) => (
+            <div key={label} className="flex items-center">
+              <button
+                className={`body-2-semibold rounded-full px-3.5 py-2.25 ${
+                  selected === label ? "text-red-main" : "text-gray-500"
+                }`}
+                onClick={() => handleCategoryClick(label)}
+              >
+                {label}
+              </button>
+              {label === "최신" && (
+                <div className="mx-2 h-4 w-px bg-gray-800" />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {isLoading ? (
+          <div className="flex flex-col gap-4">
+            {Array.from({ length: 4 }).map((_, idx) => (
+              <CardSkeleton key={idx} />
             ))}
           </div>
-
-          {isLoading ? (
-            <div className="flex flex-col gap-4">
-              {Array.from({ length: 4 }).map((_, idx) => (
-                <CardSkeleton key={idx} />
-              ))}
-            </div>
-          ) : events.length === 0 ? (
-            <div className="mb-80 flex flex-col items-center justify-center pt-30 text-center text-gray-500">
-              <EmptyIcon />
-              <p className="body-3-medium mt-3.5 mb-7 text-gray-800">
-                아직 모집 이벤트가 없어요 <br />
-                지금 바로 나만의 이벤트를 만들어보세요
-              </p>
-              <button
-                onClick={() => router.push(PATHS.EVENT_CREATE)}
-                className="bg-red-main body-3-semibold w-75 rounded-xl px-6 py-4 text-white"
-              >
-                나만의 이벤트 만들러 가기
-              </button>
-            </div>
-          ) : (
-            events.map((event) => (
-              <div key={event.eventId}>
-                <Card
-                  id={String(event.eventId)}
-                  imageUrl={event.posterImageUrl}
-                  category={event.mediaType}
-                  title={event.mediaTitle}
-                  placeAndDate={`${event.locationName} · ${event.eventDate}`}
-                  description={event.description}
-                  ddayBadge={`D-${event.d_day}`}
-                  statusBadge={event.eventStatus}
-                  progressRate={`${event.rate}%`}
-                  estimatedPrice={String(event.estimatedPrice)}
-                  query={{
-                    from: "home",
-                    category: categoryMap[selected],
-                  }}
-                />
-                <div className="my-4 h-0.25 w-full bg-gray-950" />
-              </div>
-            ))
-          )}
-
-          {events.length > 0 && events.length <= 4 && (
-            <div
-              className={
-                {
-                  1: "h-105",
-                  2: "h-72",
-                  3: "h-56",
-                  4: "h-40",
-                }[events.length]
-              }
-            />
-          )}
-
-          {events.length === 5 && (
-            <Button
-              className="mt-5 mb-5"
-              variant="secondary"
-              onClick={() => {
-                const categorySlug = categoryMap[selected];
-                router.push(`/category/${categorySlug}`);
-              }}
+        ) : events.length === 0 ? (
+          <div className="mb-80 flex flex-col items-center justify-center pt-30 text-center text-gray-500">
+            <EmptyIcon />
+            <p className="body-3-medium mt-3.5 mb-7 text-gray-800">
+              아직 모집 이벤트가 없어요 <br />
+              지금 바로 나만의 이벤트를 만들어보세요
+            </p>
+            <button
+              onClick={() => router.push(PATHS.EVENT_CREATE)}
+              className="bg-red-main body-3-semibold w-75 rounded-xl px-6 py-4 text-white"
             >
-              더보기
-            </Button>
-          )}
+              나만의 이벤트 만들러 가기
+            </button>
+          </div>
+        ) : (
+          events.map((event) => (
+            <div key={event.eventId}>
+              <Card
+                id={String(event.eventId)}
+                imageUrl={event.posterImageUrl}
+                category={event.mediaType}
+                title={event.mediaTitle}
+                placeAndDate={`${event.locationName} · ${event.eventDate}`}
+                description={event.description}
+                ddayBadge={`D-${event.d_day}`}
+                statusBadge={event.eventStatus}
+                progressRate={`${event.rate}%`}
+                estimatedPrice={String(event.estimatedPrice)}
+                query={{ from: "home", category: categoryMap[selected] }}
+              />
+              <div className="my-4 h-0.25 w-full bg-gray-950" />
+            </div>
+          ))
+        )}
 
-          {events.length === 1 && <div className="h-105" />}
-        </motion.section>
-      </div>
-    </>
+        {events.length > 0 && events.length <= 4 && (
+          <div
+            className={
+              {
+                1: "h-105",
+                2: "h-72",
+                3: "h-56",
+                4: "h-40",
+              }[events.length]
+            }
+          />
+        )}
+
+        {events.length === 5 && (
+          <Button
+            className="mt-5 mb-5"
+            variant="secondary"
+            onClick={() => {
+              const categorySlug = categoryMap[selected];
+              router.push(`/category/${categorySlug}`);
+            }}
+          >
+            더보기
+          </Button>
+        )}
+
+        {events.length === 1 && <div className="h-105" />}
+      </motion.section>
+    </div>
   );
 }

--- a/src/app/_apis/auth/user-type/user-type-queries.ts
+++ b/src/app/_apis/auth/user-type/user-type-queries.ts
@@ -10,5 +10,6 @@ export const USER_TYPE_OPTION = {
     queryOptions({
       queryKey: USER_TYPE_KEY.RESULT(),
       queryFn: () => getUserTypeResult(),
+      staleTime: 1000 * 60 * 60 * 24,
     }),
 };

--- a/src/app/_components/button.tsx
+++ b/src/app/_components/button.tsx
@@ -2,7 +2,6 @@
 
 import { ButtonHTMLAttributes } from "react";
 import { cn } from "../_utils/cn";
-import { useLoading } from "app/_context/loading-context";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
@@ -16,24 +15,18 @@ export default function Button({
   className,
   variant = "primary",
   disabled,
-  isLoading,
+  isLoading = false,
   ...props
 }: ButtonProps) {
-  const { isLoading: globalLoading } = useLoading();
-  const effectiveLoading = isLoading ?? globalLoading;
-
-  const isActuallyDisabled = disabled || effectiveLoading;
+  const isActuallyDisabled = disabled || isLoading;
 
   const buttonStyles = cn(
     "body-3-medium w-full rounded-xl py-4 flex items-center justify-center transition-colors",
     variant === "primary" && "text-gray-white bg-red-main",
     variant === "secondary" && "bg-gray-950 text-gray-300",
-    !effectiveLoading &&
-      !disabled &&
-      variant === "primary" &&
-      "active:bg-red-700",
+    !isLoading && !disabled && variant === "primary" && "active:bg-red-700",
     disabled &&
-      !effectiveLoading &&
+      !isLoading &&
       "bg-gray-900 text-gray-700 cursor-not-allowed active:bg-gray-900",
     className,
   );
@@ -45,7 +38,7 @@ export default function Button({
       disabled={isActuallyDisabled}
       {...props}
     >
-      {effectiveLoading ? (
+      {isLoading ? (
         <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
       ) : (
         children

--- a/src/app/_hooks/events/use-category-events.ts
+++ b/src/app/_hooks/events/use-category-events.ts
@@ -1,12 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { getEventsByCategory } from "app/_apis/events/category";
 
-export const useCategoryEvents = (category: string) => {
+export const useCategoryEvents = (
+  category: string,
+  options?: {
+    enabled?: boolean;
+  },
+) => {
   return useQuery({
     queryKey: ["category-events", category],
-    queryFn: () => getEventsByCategory(category, 0, 5),
-    staleTime: 1000 * 60 * 5,
-    enabled: !!category,
+    queryFn: () => getEventsByCategory(category),
+    staleTime: 1000 * 60, // optional
+    ...options, // enabled 등 외부 옵션 허용
   });
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import ToastRenderer from "./_components/toast-renderer";
 import Script from "next/script";
 import { ToastProvider } from "./_context/toast-context";
 import Toast from "./_components/noti-toast";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import ServiceWorkerDebug from "./_components/ServiceWorkerDebug";
 import DebugLogger from "./_components/debug-logger";
 import { LoadingProvider } from "./_context/loading-context";
@@ -43,6 +42,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head>
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" href="/images/favicon/48x48.png" />
+        <meta
+          name="naver-site-verification"
+          content="7dd8da1c8834169e1812e1266f327334c8462dc0"
+        />
       </head>
       <body>
         <ToastProvider>
@@ -56,7 +59,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <ReactQueryProvider>
             <ServiceWorkerDebug />
             <LoadingProvider> {children}</LoadingProvider>
-            <SpeedInsights />
             <Toast />
           </ReactQueryProvider>
         </ToastProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             src="https://developers.kakao.com/sdk/js/kakao.js"
             strategy="beforeInteractive"
           />
-          <InAppRedirect />
+          {/* <InAppRedirect /> */}
           <ToastRenderer />
           <ReactQueryProvider>
             <ServiceWorkerDebug />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #304 

---
## 📋 작업 상세 내용
-  스크린샷처럼 작은화면에서는 아래텍스트랑 포스터이미지랑 겹쳐서 이미지 조금 줄이고 텍스트 위에 그라이데이션없앴습니다
- home 진입할때 카테고리 데이터 다 가져오는 문제 있어서, 인기최신만 미리 가져오도록 최적화햇습니다
- 그리고 유형결과 페이지는 처음 테스트 이후 동일해서 1일 캐시되도록 수정했고
- 버튼에 계속 스피너 도는 문제있어서 해결했습니다
- layout에 메타태그는 구글과 다르게 네이버에 사이트등록하려면 필요해서 추가

- 아아ㅏ 그리고 레이아웃파일에 인앱리다이렉트로 카카오브라우저나, 크롬 등등일때 사파리로 강제 리다이렉트해서 열리도록 했었는데(목적은 사파리 기준으로 동일한 css 보여줄려고) 근데 카카오 로그인하고 다시 사파리로 돌아와야하는등 뭔가... 더 불편한 느낌..? 일단 주석처리해둬서 테스트해보고 바꾸면 될것 같스빈다ㅏ(근데또 인앱브라우저에서는 화면크기가 se처럼 작아서 만약 인앱리다이렉트 없앤다면 화면크기를 더 신경써줘야할것같습니더ㅏ)
---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->
<img width="393" height="676" alt="스크린샷 2025-08-05 215025" src="https://github.com/user-attachments/assets/7bd5e2c1-27da-4f14-bc31-0c441a0832ee" />
<img width="405" height="692" alt="스크린샷 2025-08-05 215003" src="https://github.com/user-attachments/assets/891686e1-a54d-4e4d-bce1-8e9b3736c9be" />


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
