### PR TITLE
[Bug/#306] 유형결과 페이지 에러해결, css색상 수정

### DIFF
--- a/src/app/(fullscreen)/event/success/_components/client.tsx
+++ b/src/app/(fullscreen)/event/success/_components/client.tsx
@@ -10,6 +10,7 @@ import { PATHS } from "@/constants";
 import { useCreateEvent } from "app/_hooks/use-create-event";
 import Complete from "@/components/complete";
 import { useLoading } from "app/_context/loading-context";
+import Modal from "@/components/modal";
 
 export default function Client() {
   const [step, setStep] = useState(1);
@@ -17,6 +18,7 @@ export default function Client() {
   const { formData, resetFormData } = useEventFormStore();
   const { mutate } = useCreateEvent();
   const { setLoading, isLoading } = useLoading();
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
 
   const handleButtonClick = () => {
     if (step === 1) {
@@ -35,6 +37,17 @@ export default function Client() {
         },
       });
     }
+  };
+  const handleCloseClick = () => {
+    setShowExitConfirm(true);
+  };
+  const handleConfirmExit = () => {
+    setShowExitConfirm(false);
+    useEventFormStore.getState().resetFormData();
+    router.push(PATHS.EVENT);
+  };
+  const handleCancelExit = () => {
+    setShowExitConfirm(false);
   };
 
   const handleComplete = () => {
@@ -57,11 +70,23 @@ export default function Client() {
           onButtonClick={handleButtonClick}
           isLoading={isLoading}
           title="이벤트 미리보기"
+          onClose={handleCloseClick}
           state="preview"
         >
           {step === 1 && <Step1 />}
           {step === 2 && <Step2 />}
         </FixedLayout>
+      )}
+      {showExitConfirm && (
+        <Modal
+          iconType="alert"
+          title="이벤트 생성을 취소할까요?"
+          children="지금까지 작성한 내용은 저장되지 않아요"
+          confirmText="생성 취소하기"
+          cancelText="아니오"
+          onConfirm={handleConfirmExit}
+          onCancel={handleCancelExit}
+        />
       )}
     </>
   );

--- a/src/app/(fullscreen)/intro/page.tsx
+++ b/src/app/(fullscreen)/intro/page.tsx
@@ -34,19 +34,23 @@ export default function Intro() {
         minHeight: "calc(100dvh + env(safe-area-inset-top))",
       }}
     >
-      <Image
-        src="/images/custom-bg.webp"
-        alt="Intro Background"
-        fill
-        priority
-        placeholder="blur"
-        blurDataURL="/images/custom-bg.webp"
-        className="z-0 object-cover"
+      <div
+        className="absolute inset-0 z-0"
         style={{
           top: "calc(-1 * env(safe-area-inset-top))",
           height: "calc(100% + env(safe-area-inset-top))",
         }}
-      />
+      >
+        <Image
+          src="/images/custom-bg.webp"
+          alt="Intro Background"
+          fill
+          priority
+          placeholder="blur"
+          blurDataURL="/images/custom-bg.webp"
+          className="object-cover"
+        />
+      </div>
       <div
         className="absolute left-1/2 z-10 -translate-x-1/2 -translate-y-1/2 text-center"
         style={{

--- a/src/app/(fullscreen)/intro/page.tsx
+++ b/src/app/(fullscreen)/intro/page.tsx
@@ -26,10 +26,12 @@ export default function Intro() {
 
   return (
     <main
-      className="relative w-full bg-cover bg-center"
+      className="fixed inset-0 w-full bg-cover bg-center"
       style={{
-        height: "calc(100dvh + env(safe-area-inset-top))",
+        height: "100dvh",
+        paddingTop: "env(safe-area-inset-top)",
         marginTop: "calc(-1 * env(safe-area-inset-top))",
+        minHeight: "calc(100dvh + env(safe-area-inset-top))",
       }}
     >
       <Image
@@ -40,8 +42,17 @@ export default function Intro() {
         placeholder="blur"
         blurDataURL="/images/custom-bg.webp"
         className="z-0 object-cover"
+        style={{
+          top: "calc(-1 * env(safe-area-inset-top))",
+          height: "calc(100% + env(safe-area-inset-top))",
+        }}
       />
-      <div className="absolute top-[47.14%] left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
+      <div
+        className="absolute left-1/2 z-10 -translate-x-1/2 -translate-y-1/2 text-center"
+        style={{
+          top: "calc(50% - env(safe-area-inset-top) / 2)",
+        }}
+      >
         <div className="flex flex-col items-center">
           <LogoWhiteIcon width={100} height={100} />
           <h1 className="body-2-medium -mt-2 text-white">

--- a/src/app/(fullscreen)/trait/result/page.tsx
+++ b/src/app/(fullscreen)/trait/result/page.tsx
@@ -17,38 +17,41 @@ export default function TraitResult() {
   const router = useRouter();
   const from = searchParams.get("from");
 
+  const { data } = useGetUserTypeResult();
+  const setUser = useUserStore((state) => state.setUser);
+  const user = useUserStore((state) => state.user);
+
   const isFromMyPage = from === "mypage";
 
   const handleClick = () => {
     router.push(PATHS.HOME);
   };
 
-  const { data } = useGetUserTypeResult();
-  const setUser = useUserStore((state) => state.setUser);
-  const user = useUserStore((state) => state.user);
-
   useEffect(() => {
     if (!user || !data?.title) return;
-    if (user.userTypeTitle === data.title) return;
-    const cleanedTitle = data.title.replace(/\n/g, " ");
-    setUser({ ...user, userTypeTitle: cleanedTitle });
-  }, [data?.title, user, setUser]);
 
+    const cleanedTitle = data.title.replace(/\n/g, " ");
+    if (user.userTypeTitle !== cleanedTitle) {
+      setTimeout(() => {
+        setUser({ ...user, userTypeTitle: cleanedTitle });
+      }, 0);
+    }
+  }, [data?.title]);
   useEffect(() => {
     const handleResize = () => {
       setIsShortScreen(window.innerHeight < 700);
     };
 
-    handleResize();
-    const debounced = setTimeout(() => {
+    if (typeof window !== "undefined") {
+      handleResize();
       window.addEventListener("resize", handleResize);
-    }, 100);
-
-    return () => {
-      clearTimeout(debounced);
-      window.removeEventListener("resize", handleResize);
-    };
+      return () => window.removeEventListener("resize", handleResize);
+    }
   }, []);
+
+  if (!data) {
+    return null;
+  }
 
   const iconSet =
     USER_TYPE_ICONS[data?.userTypeCode as keyof typeof USER_TYPE_ICONS] ??

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -211,7 +211,7 @@ export default function Home() {
 
         {events.length > 5 && (
           <Button
-            className="mt-5 mb-5"
+            className="mt-5 mb-5 active:bg-gray-900"
             variant="secondary"
             onClick={() => {
               const categorySlug = categoryMap[selected];

--- a/src/app/_components/bottom-navibar.tsx
+++ b/src/app/_components/bottom-navibar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import Link from "next/link";
 import { NAVIGATION_TABS } from "app/_constants";
 import LightEffect from "./light-effect";
 import { useNotificationStore } from "app/_stores/use-noti";

--- a/src/app/_components/main-card.tsx
+++ b/src/app/_components/main-card.tsx
@@ -27,7 +27,7 @@ function Card({
 
   return (
     <div className="relative flex h-30 w-full gap-3" onClick={handleClick}>
-      <div className="relative h-30 w-30 overflow-hidden rounded-md">
+      <div className="relative h-30 w-30 overflow-hidden rounded-[8px]">
         <Image
           src={imageUrl || "/images/default-image.png"}
           alt={title}

--- a/src/app/_constants/metadata.ts
+++ b/src/app/_constants/metadata.ts
@@ -26,4 +26,5 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  viewportFit: "cover",
 };

--- a/src/app/_styles/base.css
+++ b/src/app/_styles/base.css
@@ -46,7 +46,7 @@ input:-webkit-autofill {
 }
 
 input {
-  caret-color: white; 
+  caret-color: white;
 }
 /* 스크롤바 스타일 */
 ::-webkit-scrollbar {
@@ -62,4 +62,11 @@ input {
 }
 ::-webkit-scrollbar-thumb:hover {
   background-color: rgba(100, 100, 100, 0.8);
+}
+
+@supports (padding: max(0px)) {
+  body {
+    padding-top: constant(safe-area-inset-top); /* iOS 11.0 */
+    padding-top: env(safe-area-inset-top); /* iOS 11.2+ */
+  }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #306 

---
## 📋 작업 상세 내용
- 유형결과페이지 접속안되는 문제 해결
- 더보기 active색상 추가, 
- 이벤트미리보기, 게시하기 페이지에서 헤더close 버튼 -> 재확인 모달 추가
- 인트로 노치 배경이미지 확장 다시 시도 

---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->
<img width="427" height="872" alt="image" src="https://github.com/user-attachments/assets/e8169a2b-d947-45f7-b598-9cb58e9ec44a" />

<img width="412" height="852" alt="image" src="https://github.com/user-attachments/assets/d28a755d-2f93-4dec-9871-130ce09739ad" />

## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
