### PR TITLE
[Bug/#343] 노치대응 헤더영역 수정, 상세페이지 generateMetadata 추가 

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "Checking your commit message ฅ^•ﻌ•^ฅ"
 pnpm commitlint --edit "$1"

--- a/src/app/(fullscreen)/detail/[id]/detail-client.tsx
+++ b/src/app/(fullscreen)/detail/[id]/detail-client.tsx
@@ -1,4 +1,3 @@
-// app/(fullscreen)/event/[id]/detail-client.tsx
 "use client";
 
 import { Button } from "@/components";

--- a/src/app/(fullscreen)/detail/[id]/detail-client.tsx
+++ b/src/app/(fullscreen)/detail/[id]/detail-client.tsx
@@ -1,0 +1,264 @@
+// app/(fullscreen)/event/[id]/detail-client.tsx
+"use client";
+
+import { Button } from "@/components";
+import TopBar from "../_components/top-bar";
+import DetailContent from "@/components/detail-content";
+import { useParams, useRouter } from "next/navigation";
+import {
+  useDeleteEvent,
+  useDeleteEventsRecruit,
+  useGetEvent,
+  usePostEventRegister,
+  usePostEventsVenue,
+} from "app/_hooks/events/use-events";
+import { useState, useEffect, useMemo } from "react";
+import Modal from "@/components/modal";
+import Complete from "@/components/complete";
+import { MODAL_CONTENT } from "@/constants/detail";
+import { PATHS } from "@/constants";
+import { useGetToTicket } from "app/_hooks/ticket/use-ticket";
+import { useGetAnonymousEvent } from "app/_hooks/use-anonymous-events";
+import { EventData } from "app/_types/event";
+import { useUserStore } from "app/_stores/use-user-store";
+import { useLoading } from "app/_context/loading-context";
+import { useToastStore } from "app/_stores/use-toast-store";
+import { devError } from "@/utils/dev-logger";
+
+type ModalType =
+  | "apply"
+  | "cancel"
+  | "recruitCancel"
+  | "venueApply"
+  | "loginRequired"
+  | null;
+
+export default function DetailClient() {
+  const router = useRouter();
+  const [modalType, setModalType] = useState<ModalType>(null);
+  const [isComplete, setIsComplete] = useState(false);
+  const [shouldPoll, setShouldPoll] = useState(true);
+
+  const { setLoading } = useLoading();
+  const params = useParams();
+  const eventId = useMemo(() => Number(params?.id), [params?.id]);
+  const isValidEventId = !isNaN(eventId) && eventId > 0;
+
+  const user = useUserStore((state) => state.user);
+  const loggedIn = !!user;
+
+  const { data: dataWithAuth, isPending: isPendingWithAuth } = useGetEvent(
+    eventId,
+    {
+      enabled: loggedIn && isValidEventId,
+      refetchInterval: shouldPoll ? 5000 : false,
+    },
+  );
+
+  const { data: dataAnonymousRaw, isPending: isPendingAnonymous } =
+    useGetAnonymousEvent(eventId, {
+      enabled: !loggedIn && isValidEventId,
+    });
+
+  const data = (loggedIn ? dataWithAuth : dataAnonymousRaw) as
+    | EventData
+    | undefined;
+
+  useEffect(() => {
+    if (data?.buttonState?.trim() === "티켓으로 이동") {
+      setShouldPoll(false);
+    }
+  }, [data?.buttonState]);
+
+  const isPending = loggedIn ? isPendingWithAuth : isPendingAnonymous;
+  const { data: moveToTicket } = useGetToTicket(eventId, {
+    enabled: data?.buttonState === "티켓으로 이동",
+  });
+
+  const handleClick = () => {
+    if (!loggedIn) {
+      setModalType("loginRequired");
+      return;
+    }
+    switch (data?.buttonState) {
+      case "신청하기":
+        setModalType("apply");
+        break;
+      case "신청 취소":
+        setModalType("cancel");
+        break;
+      case "모집 취소":
+        setModalType("recruitCancel");
+        break;
+      case "티켓으로 이동":
+        if (moveToTicket?.ticketId)
+          router.push(`${PATHS.TICKET}/${moveToTicket.ticketId}`);
+        else if (eventId) router.push(`${PATHS.TICKET}?eventId=${eventId}`);
+        break;
+      case "대관 신청하기":
+        setModalType("venueApply");
+        break;
+      default:
+        setModalType("apply");
+    }
+  };
+
+  const { mutate } = usePostEventRegister();
+  const { mutate: applyCancel } = useDeleteEvent();
+  const { mutate: recruitCancel } = useDeleteEventsRecruit();
+  const { mutate: postEventVenue } = usePostEventsVenue();
+
+  const handleApply = () => {
+    setLoading(true);
+    setIsComplete(true);
+    mutate(eventId, {
+      onSuccess: () => setLoading(false),
+      onError: (err: any) => {
+        setLoading(false);
+        const code = err?.response?.data?.code;
+        if (code === "PARTICIPATION_404") {
+          useToastStore
+            .getState()
+            .showToast(
+              "해당 날짜에 이미 참여 중인 이벤트가 있어요",
+              "checkbox",
+            );
+        } else {
+          devError("이벤트 신청 실패:", err);
+        }
+        setIsComplete(false);
+      },
+    });
+  };
+
+  const handleCancel = () => {
+    setLoading(true);
+    applyCancel(eventId, {
+      onSuccess: () => setLoading(false),
+      onError: (error) => {
+        devError("이벤트 신청 취소 실패:", error);
+        setLoading(false);
+      },
+    });
+  };
+
+  const handleRecruitCancel = () => {
+    setLoading(true);
+    recruitCancel(eventId, { onSettled: () => setLoading(false) });
+  };
+
+  const handleVenueApply = (type: number) => {
+    setLoading(true);
+    postEventVenue({ eventId, type }, { onSettled: () => setLoading(false) });
+  };
+
+  const handleComplete = () => router.push(PATHS.EVENT);
+
+  const currentModal =
+    modalType && modalType !== "loginRequired"
+      ? MODAL_CONTENT[modalType]
+      : null;
+
+  if (isComplete) {
+    return (
+      <Complete
+        status="success"
+        action="이벤트 신청"
+        buttonText="신청목록 확인하기"
+        onButtonClick={handleComplete}
+      />
+    );
+  }
+
+  return (
+    <>
+      {data && (
+        <>
+          <TopBar
+            event={{
+              eventId: data.eventId,
+              posterImageUrl: data.posterImageUrl,
+              title: data.eventTitle,
+              description: data.description,
+            }}
+          />
+          <DetailContent {...data} />
+        </>
+      )}
+
+      {!isPending && (
+        <div className="bg-gray-black fixed bottom-0 flex w-full max-w-125 gap-9.5 px-5 pt-4.25 pb-10.75">
+          <div
+            className={`flex flex-col justify-center ${
+              data?.eventState === "모집 취소" ||
+              data?.eventState === "대관 취소"
+                ? "opacity-30"
+                : ""
+            }`}
+          >
+            <p className="caption-1-medium text-gray-500">예상 가격</p>
+            <p className="body-2-semibold whitespace-nowrap text-gray-200">
+              {data?.estimatedPrice?.toLocaleString?.() ?? "-"}원
+            </p>
+          </div>
+
+          <Button
+            variant="primary"
+            onClick={handleClick}
+            disabled={
+              data?.eventState === "모집 취소" ||
+              (data?.eventState === "모집 완료" &&
+                data?.userRole !== "주최자") ||
+              data?.eventState === "대관 취소" ||
+              data?.buttonState === "대관 진행 중" ||
+              data?.buttonState === "신청 마감"
+            }
+          >
+            {data?.buttonState ?? ""}
+          </Button>
+        </div>
+      )}
+
+      {modalType === "loginRequired" ? (
+        <Modal
+          iconType="alert"
+          title={`이벤트 신청은\n로그인 후에 가능해요`}
+          children="지금 바로 로그인하고 신청해보세요"
+          confirmText="로그인하기"
+          onConfirm={() => {
+            router.push(PATHS.LOGIN);
+            setModalType(null);
+          }}
+          onClose={() => setModalType(null)}
+        />
+      ) : (
+        modalType && (
+          <Modal
+            iconType={
+              (currentModal?.iconType as "confirm" | "alert" | "") || "confirm"
+            }
+            title={currentModal?.title || ""}
+            confirmText={currentModal?.confirmText || "확인"}
+            cancelText={currentModal?.cancelText || "취소"}
+            onConfirm={() => {
+              if (modalType === "apply") handleApply();
+              if (modalType === "cancel") handleCancel();
+              if (modalType === "recruitCancel") handleRecruitCancel();
+              if (modalType === "venueApply") handleVenueApply(0);
+              setModalType(null);
+            }}
+            onCancel={() => {
+              if (modalType === "venueApply") handleVenueApply(1);
+              setModalType(null);
+            }}
+            showCloseButton={currentModal?.showCloseButton}
+            onClose={() => setModalType(null)}
+            isVerticalLayout={currentModal?.isVerticalLayout}
+          >
+            {currentModal?.description}
+          </Modal>
+        )
+      )}
+    </>
+  );
+}

--- a/src/app/(fullscreen)/detail/[id]/page.tsx
+++ b/src/app/(fullscreen)/detail/[id]/page.tsx
@@ -1,302 +1,101 @@
-"use client";
+import type { Metadata } from "next";
+import DetailClient from "./detail-client";
 
-import { Button } from "@/components";
-import TopBar from "../_components/top-bar";
-import DetailContent from "@/components/detail-content";
-import { useParams, useRouter } from "next/navigation";
-import {
-  useDeleteEvent,
-  useDeleteEventsRecruit,
-  useGetEvent,
-  usePostEventRegister,
-  usePostEventsVenue,
-} from "app/_hooks/events/use-events";
-import { useState, useEffect, useMemo } from "react";
-import Modal from "@/components/modal";
-import Complete from "@/components/complete";
-import { MODAL_CONTENT } from "@/constants/detail";
-import { PATHS } from "@/constants";
-import { useGetToTicket } from "app/_hooks/ticket/use-ticket";
-import { useGetAnonymousEvent } from "app/_hooks/use-anonymous-events";
-import { EventData } from "app/_types/event";
-import { useUserStore } from "app/_stores/use-user-store";
-import { useLoading } from "app/_context/loading-context";
-import { useToastStore } from "app/_stores/use-toast-store";
-import { devError } from "@/utils/dev-logger";
+function absolutize(src?: string) {
+  if (!src) return undefined;
+  try {
+    return new URL(
+      src,
+      process.env.NEXT_PUBLIC_BASE_URL ?? "https://movie-bookie.shop",
+    ).toString();
+  } catch {
+    return undefined;
+  }
+}
 
-type ModalType =
-  | "apply"
-  | "cancel"
-  | "recruitCancel"
-  | "venueApply"
-  | "loginRequired"
-  | null;
+async function fetchEventMeta(id: string) {
+  const base = process.env.NEXT_PUBLIC_API_URL;
+  const url = `${base}/api/events/anonymous/${id}`;
 
-const LOGIN_REQUIRED_MODAL = {
-  iconType: "alert" as const,
-  title: "이벤트 신청은 로그인 후에 가능해요",
-  description: "지금 바로 로그인하고 신청해보세요",
-  confirmText: "로그인하기",
-  cancelText: "취소",
-};
-
-export default function Detail() {
-  const router = useRouter();
-  const [modalType, setModalType] = useState<ModalType>(null);
-  const [isComplete, setIsComplete] = useState(false);
-  const [shouldPoll, setShouldPoll] = useState(true);
-  const showToast = useToastStore((state) => state.showToast);
-
-  const { setLoading } = useLoading();
-
-  const params = useParams();
-  const eventId = useMemo(() => Number(params?.id), [params?.id]);
-  const isValidEventId = !isNaN(eventId) && eventId > 0;
-
-  const user = useUserStore((state) => state.user);
-  const loggedIn = !!user;
-
-  const { data: dataWithAuth, isPending: isPendingWithAuth } = useGetEvent(
-    eventId,
-    {
-      enabled: loggedIn && isValidEventId,
-      refetchInterval: shouldPoll ? 5000 : false,
-    },
-  );
-
-  const { data: dataAnonymousRaw, isPending: isPendingAnonymous } =
-    useGetAnonymousEvent(eventId, {
-      enabled: !loggedIn && isValidEventId,
-    });
-
-  const data = (loggedIn ? dataWithAuth : dataAnonymousRaw) as
-    | EventData
-    | undefined;
-
-  useEffect(() => {
-    if (data?.buttonState?.trim() === "티켓으로 이동") {
-      setShouldPoll(false);
-    }
-  }, [data?.buttonState]);
-
-  const isPending = loggedIn ? isPendingWithAuth : isPendingAnonymous;
-
-  const { data: moveToTicket } = useGetToTicket(eventId, {
-    enabled: data?.buttonState === "티켓으로 이동",
+  const res = await fetch(url, {
+    next: { revalidate: 120 },
   });
 
-  const handleClick = () => {
-    if (!loggedIn) {
-      setModalType("loginRequired");
-      return;
-    }
+  if (!res.ok) return null;
 
-    switch (data?.buttonState) {
-      case "신청하기":
-        setModalType("apply");
-        break;
-      case "신청 취소":
-        setModalType("cancel");
-        break;
-      case "모집 취소":
-        setModalType("recruitCancel");
-        break;
-      case "티켓으로 이동":
-        if (moveToTicket?.ticketId) {
-          router.push(`${PATHS.TICKET}/${moveToTicket.ticketId}`);
-        } else if (eventId) {
-          router.push(`${PATHS.TICKET}?eventId=${eventId}`);
-        }
-        break;
-      case "대관 신청하기":
-        setModalType("venueApply");
-        break;
-      default:
-        setModalType("apply");
-    }
+  const data = (await res.json()) as { result: any };
+  if (!data?.result) return null;
+
+  const r = data.result;
+  return {
+    id: r.eventId,
+    title: r.eventTitle || r.mediaTitle || "무비부키 이벤트",
+    description: r.description,
+    image: absolutize(r.posterImageUrl) ?? absolutize(r.locationImageUrl),
   };
+}
 
-  const { mutate } = usePostEventRegister();
-  const { mutate: applyCancel } = useDeleteEvent();
-  const { mutate: recruitCancel } = useDeleteEventsRecruit();
-  const { mutate: postEventVenue } = usePostEventsVenue();
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> {
+  const meta = await fetchEventMeta(params.id);
 
-  const handleApply = () => {
-    setLoading(true);
-    setIsComplete(true);
+  if (!meta) {
+    const title = "이벤트를 찾을 수 없어요 | 무비부키";
+    const description = "해당 이벤트가 존재하지 않거나 만료되었습니다.";
+    const url = `/event/${params.id}`;
+    const image = "/images/thumbnail.png";
 
-    mutate(eventId, {
-      onSuccess: () => {
-        setLoading(false);
+    return {
+      title,
+      description,
+      alternates: { canonical: url },
+      openGraph: {
+        type: "article",
+        url,
+        title,
+        description,
+        images: [{ url: image, width: 1200, height: 630 }],
       },
-      onError: (err: any) => {
-        setLoading(false);
-
-        const code = err?.response?.data?.code;
-
-        if (code === "PARTICIPATION_404") {
-          useToastStore
-            .getState()
-            .showToast(
-              "해당 날짜에 이미 참여 중인 이벤트가 있어요",
-              "checkbox",
-            );
-        } else {
-          devError("이벤트 신청 실패:", err);
-        }
-        setIsComplete(false);
-        setLoading(false);
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [image],
       },
-    });
-  };
-
-  const handleCancel = () => {
-    setLoading(true);
-    applyCancel(eventId, {
-      onSuccess: () => {
-        setLoading(false);
-      },
-      onError: (error) => {
-        devError("이벤트 신청 취소 실패:", error);
-        setLoading(false);
-      },
-    });
-  };
-
-  const handleRecruitCancel = () => {
-    setLoading(true);
-    recruitCancel(eventId, {
-      onSettled: () => {
-        setLoading(false);
-      },
-    });
-  };
-
-  const handleVenueApply = (type: number) => {
-    setLoading(true);
-    postEventVenue(
-      { eventId, type },
-      {
-        onSettled: () => {
-          setLoading(false);
-        },
-      },
-    );
-  };
-
-  const handleComplete = () => {
-    router.push(PATHS.EVENT);
-  };
-
-  const currentModal =
-    modalType && modalType !== "loginRequired"
-      ? MODAL_CONTENT[modalType]
-      : null;
-
-  const handleModalClose = () => {
-    setModalType(null);
-  };
-
-  if (isComplete) {
-    return (
-      <Complete
-        status="success"
-        action="이벤트 신청"
-        buttonText="신청목록 확인하기"
-        onButtonClick={handleComplete}
-      />
-    );
+      robots: { index: true, follow: true },
+    };
   }
 
-  return (
-    <>
-      {loggedIn && data && (
-        <TopBar
-          event={{
-            eventId: data.eventId,
-            posterImageUrl: data.posterImageUrl,
-            title: data.eventTitle,
-            description: data.description,
-          }}
-        />
-      )}
+  const title = meta.title;
+  const description =
+    meta.description?.slice(0, 120) || "영화관 모임을 시작해보세요.";
+  const url = `/event/${meta.id}`;
+  const image = meta.image ?? "/images/thumbnail.png";
 
-      {data && <DetailContent {...data} />}
+  return {
+    title: `${title} | 무비부키`,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "article",
+      url,
+      title,
+      description,
+      images: [{ url: image, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+    robots: { index: true, follow: true },
+  };
+}
 
-      {!isPending && (
-        <div className="bg-gray-black fixed bottom-0 flex w-full max-w-125 gap-9.5 px-5 pt-4.25 pb-10.75">
-          <div
-            className={`flex flex-col justify-center ${
-              data?.eventState === "모집 취소" ||
-              data?.eventState === "대관 취소"
-                ? "opacity-30"
-                : ""
-            }`}
-          >
-            <p className="caption-1-medium text-gray-500">예상 가격</p>
-            <p className="body-2-semibold whitespace-nowrap text-gray-200">
-              {data?.estimatedPrice?.toLocaleString?.() ?? "-"}원
-            </p>
-          </div>
-
-          <Button
-            variant="primary"
-            onClick={handleClick}
-            disabled={
-              data?.eventState === "모집 취소" ||
-              (data?.eventState === "모집 완료" &&
-                data?.userRole !== "주최자") ||
-              data?.eventState === "대관 취소" ||
-              data?.buttonState === "대관 진행 중" ||
-              data?.buttonState === "신청 마감"
-            }
-          >
-            {data?.buttonState ?? ""}
-          </Button>
-        </div>
-      )}
-
-      {modalType === "loginRequired" ? (
-        <Modal
-          iconType="alert"
-          title={`이벤트 신청은\n로그인 후에 가능해요`}
-          children="지금 바로 로그인하고 신청해보세요"
-          confirmText="로그인하기"
-          onCancel={undefined}
-          onConfirm={() => {
-            router.push(PATHS.LOGIN);
-            setModalType(null);
-          }}
-          onClose={() => {
-            setModalType(null);
-          }}
-        ></Modal>
-      ) : (
-        modalType && (
-          <Modal
-            iconType={currentModal?.iconType as "confirm" | "alert" | ""}
-            title={currentModal?.title || ""}
-            confirmText={currentModal?.confirmText || "확인"}
-            cancelText={currentModal?.cancelText || "취소"}
-            onConfirm={() => {
-              if (modalType === "apply") handleApply();
-              if (modalType === "cancel") handleCancel();
-              if (modalType === "recruitCancel") handleRecruitCancel();
-              if (modalType === "venueApply") handleVenueApply(0);
-              setModalType(null);
-            }}
-            onCancel={() => {
-              if (modalType === "venueApply") handleVenueApply(1);
-              setModalType(null);
-            }}
-            showCloseButton={currentModal?.showCloseButton}
-            onClose={handleModalClose}
-            isVerticalLayout={currentModal?.isVerticalLayout}
-          >
-            {currentModal?.description}
-          </Modal>
-        )
-      )}
-    </>
-  );
+export default function Page() {
+  return <DetailClient />;
 }

--- a/src/app/(fullscreen)/detail/[id]/page.tsx
+++ b/src/app/(fullscreen)/detail/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import DetailClient from "./detail-client";
 
+//절대 경로로 바꿔주는 함수
 function absolutize(src?: string) {
   if (!src) return undefined;
   try {
@@ -26,12 +27,14 @@ async function fetchEventMeta(id: string) {
   const data = (await res.json()) as { result: any };
   if (!data?.result) return null;
 
-  const r = data.result;
+  const eventdata = data.result;
   return {
-    id: r.eventId,
-    title: r.eventTitle || r.mediaTitle || "무비부키 이벤트",
-    description: r.description,
-    image: absolutize(r.posterImageUrl) ?? absolutize(r.locationImageUrl),
+    id: eventdata.eventId,
+    title: eventdata.eventTitle || eventdata.mediaTitle || "무비부키 이벤트",
+    description: eventdata.description,
+    image:
+      absolutize(eventdata.posterImageUrl) ??
+      absolutize(eventdata.locationImageUrl),
   };
 }
 
@@ -53,7 +56,7 @@ export async function generateMetadata({
       description,
       alternates: { canonical: url },
       openGraph: {
-        type: "article",
+        type: "website",
         url,
         title,
         description,
@@ -80,7 +83,7 @@ export async function generateMetadata({
     description,
     alternates: { canonical: url },
     openGraph: {
-      type: "article",
+      type: "website",
       url,
       title,
       description,

--- a/src/app/(fullscreen)/detail/_components/top-bar.tsx
+++ b/src/app/(fullscreen)/detail/_components/top-bar.tsx
@@ -44,7 +44,7 @@ export default function TopBar({ event }: TopBarProps) {
 
   return (
     <>
-      <div className="fixed-overlay-safe fixed z-100 mx-auto w-full max-w-125">
+      <div className="fixed-overlay-safe pt-safe-top fixed z-100 mx-auto w-full max-w-125">
         <button
           type="button"
           className="absolute top-2.5 left-5 h-9.5 w-9.5 rounded-full bg-gray-950"

--- a/src/app/(fullscreen)/detail/_components/top-bar.tsx
+++ b/src/app/(fullscreen)/detail/_components/top-bar.tsx
@@ -47,7 +47,7 @@ export default function TopBar({ event }: TopBarProps) {
       <div className="fixed-overlay-safe pt-safe-top fixed z-100 mx-auto w-full max-w-125">
         <button
           type="button"
-          className="absolute top-2.5 left-5 h-9.5 w-9.5 rounded-full bg-gray-950"
+          className="absolute top-2.5 left-3 h-9.5 w-9.5 rounded-full bg-gray-950"
           onClick={handleBack}
         >
           <BackIcon />

--- a/src/app/(fullscreen)/event-create/page.tsx
+++ b/src/app/(fullscreen)/event-create/page.tsx
@@ -18,7 +18,6 @@ import { useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 import { MAX_PARTICIPANTS } from "@/constants/event-create";
 import { useToastStore } from "app/_stores/use-toast-store";
-import { apiGet } from "app/_apis/methods";
 import { checkRecruitable } from "app/_apis/events/participation";
 
 const steps = [

--- a/src/app/(fullscreen)/feedback/result/components/feedbackpage.tsx
+++ b/src/app/(fullscreen)/feedback/result/components/feedbackpage.tsx
@@ -61,7 +61,7 @@ export default function FeedbackPage() {
         showBottomButton={false}
         state="default"
       >
-        <div className="text-white">
+        <div className="mt-2 text-white">
           {feedbackType && step === 1 && (
             <div className="flex flex-col">
               <div className="mb-3">

--- a/src/app/(fullscreen)/login/page.tsx
+++ b/src/app/(fullscreen)/login/page.tsx
@@ -9,27 +9,35 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { PATHS } from "@/constants";
 import PwaPromptModal from "@/components/pwa-prompt-modal";
+import { cn } from "@/utils/cn";
+import { useSmallScreen } from "app/_hooks/use-small-screen";
 
 export default function Login() {
   const router = useRouter();
   const [activeIndex, setActiveIndex] = useState(0);
+  const isSmallScreen = useSmallScreen();
 
   const handleSlideChange = (swiper: any) => {
     setActiveIndex(swiper.activeIndex);
   };
 
   return (
-    <div className="bg-gray-black relative min-h-screen text-white">
+    <div className="bg-gray-black relative min-h-screen overflow-hidden text-white">
       <PwaPromptModal />
 
-      <div className="relative">
+      <div className="relative overflow-hidden">
         <Swiper onSlideChange={handleSlideChange} className="h-full">
           {slides.map((slide, index) => (
             <SwiperSlide
               key={index}
               className="flex flex-col items-center justify-between pb-11"
             >
-              <div className="flex w-full flex-1 flex-col items-center justify-center">
+              <div
+                className={cn(
+                  isSmallScreen ? "mt-0" : "mt-10",
+                  "flex w-full flex-1 flex-col items-center justify-center",
+                )}
+              >
                 <div
                   className="px-4 pt-12 text-center"
                   style={{ whiteSpace: "pre-line" }}
@@ -39,7 +47,6 @@ export default function Login() {
                     {slide.description}
                   </p>
                 </div>
-
                 <div className="mt-5 flex w-full items-center justify-center">
                   <img
                     src={slide.gif}
@@ -53,7 +60,12 @@ export default function Login() {
           ))}
         </Swiper>
 
-        <div className="fixed bottom-[186px] left-1/2 z-20 flex -translate-x-1/2 gap-2">
+        <div
+          className={cn(
+            "absolute left-1/2 z-20 flex -translate-x-1/2 gap-2",
+            isSmallScreen ? "bottom-[20px]" : "bottom-[0px]",
+          )}
+        >
           {slides.map((_, index) => (
             <button
               type="button"

--- a/src/app/(fullscreen)/trait/result/page.tsx
+++ b/src/app/(fullscreen)/trait/result/page.tsx
@@ -73,7 +73,7 @@ export default function TraitResult() {
 
       <div
         className={`flex justify-center ${
-          isShortScreen ? "mt-8" : isFromMyPage ? "mt-32" : "mt-20"
+          isShortScreen ? "mt-15" : isFromMyPage ? "mt-32" : "mt-20"
         }`}
       >
         <div className="body-3-semibold rounded-full bg-gray-900 px-5 py-2 text-center text-gray-200">

--- a/src/app/(fullscreen)/trait/result/page.tsx
+++ b/src/app/(fullscreen)/trait/result/page.tsx
@@ -7,12 +7,14 @@ import { BackIcon, LogoWhiteIcon } from "@/icons/index";
 import { useGetUserTypeResult } from "app/_hooks/use-user-type";
 import { useUserStore } from "app/_stores/use-user-store";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { USER_TYPE_ICONS } from "@/constants/user-type-icon";
 import { useSearchParams, useRouter } from "next/navigation";
+import { cn } from "@/utils/cn";
+import { useSmallScreen } from "app/_hooks/use-small-screen";
 
 export default function TraitResult() {
-  const [isShortScreen, setIsShortScreen] = useState(false);
+  const isShortScreen = useSmallScreen();
   const searchParams = useSearchParams();
   const router = useRouter();
   const from = searchParams.get("from");
@@ -37,17 +39,6 @@ export default function TraitResult() {
       }, 0);
     }
   }, [data?.title]);
-  useEffect(() => {
-    const handleResize = () => {
-      setIsShortScreen(window.innerHeight < 700);
-    };
-
-    if (typeof window !== "undefined") {
-      handleResize();
-      window.addEventListener("resize", handleResize);
-      return () => window.removeEventListener("resize", handleResize);
-    }
-  }, []);
 
   if (!data) {
     return null;
@@ -64,7 +55,12 @@ export default function TraitResult() {
   return (
     <div className="bg-gray-black relative grid min-h-screen w-full grid-rows-[auto_1fr_auto] overflow-hidden">
       {isFromMyPage && (
-        <div className="absolute top-5 left-5 z-50">
+        <div
+          className={cn(
+            "pt-safe-top fixed top-0 left-0 z-50 w-full px-5",
+            isShortScreen ? "mt-5" : "mt-8",
+          )}
+        >
           <button
             onClick={() => router.back()}
             aria-label="뒤로가기"
@@ -136,7 +132,7 @@ export default function TraitResult() {
       </div>
 
       {!isFromMyPage && (
-        <div className="fixed bottom-0 z-50 w-full max-w-125 px-5 pt-5 pb-12">
+        <div className="pb-safe-bottom fixed bottom-0 z-50 w-full max-w-125 px-5 pt-5">
           <Button onClick={handleClick}>무비부키 시작하기</Button>
         </div>
       )}

--- a/src/app/(tabs)/my-page/page.tsx
+++ b/src/app/(tabs)/my-page/page.tsx
@@ -35,7 +35,7 @@ export default function MyPage() {
   const { handleLogout } = useLogoutHandler(() => setShowLogoutModal(false));
 
   return (
-    <div className="h-[calc(100vh-102px)] overflow-y-scroll px-5 text-white">
+    <div className="overflow-y-scroll px-5 text-white">
       <h1 className="title-1-semibold pt-6 pb-7.5">마이페이지</h1>
       <div
         className="mb-3 flex cursor-pointer items-center justify-between gap-4"

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -37,10 +37,12 @@ export default function Header({
   return (
     <header
       className={cn(
-        "bg-gray-black fixed-overlay-safe fixed top-0 z-50 flex h-[calc(50px+var(--safe-top))] w-full max-w-125 items-center justify-center focus-within:border-white",
-
+        "bg-gray-black fixed top-0 z-50 flex h-[50px] w-full max-w-125 items-center justify-center focus-within:border-white",
+        "p-[env(safe-area-inset-top)_env(safe-area-inset-right)_0_env(safe-area-inset-left)]",
+        "fixed-overlay-safe w-full",
         className,
       )}
+      style={{ paddingTop: `env(safe-area-inset-top)` }}
     >
       {showBackButton && (
         <button

--- a/src/app/_styles/base.css
+++ b/src/app/_styles/base.css
@@ -15,6 +15,7 @@ body {
   color: var(--color-gray-white);
   min-height: 100dvh;
   max-width: 500px;
+  border: 1px solid var(--color-gray-800);
 }
 
 :root {

--- a/src/app/_styles/base.css
+++ b/src/app/_styles/base.css
@@ -15,7 +15,6 @@ body {
   color: var(--color-gray-white);
   min-height: 100dvh;
   max-width: 500px;
-  border: 1px solid var(--color-gray-800);
 }
 
 :root {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #343 

---
## 📋 작업 상세 내용

- 노치 대응 헤더 영역 safe-area로 여백 추가 
- 상세 페이지 메타데이터 추가위해 폴더이동, 

### 마진 패딩준게 아니라 safe-area로 노치유무로 대응하게 해서 pwa, 브라우저 테스트필요
### 상세페이지 링크공유 OG태그되는지  배포에서 확인필요
---

## 📸 스크린샷 (선택)


